### PR TITLE
Diff tool changes to create a functional jar

### DIFF
--- a/diff-java-tool/build.gradle
+++ b/diff-java-tool/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'application'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 repositories {
@@ -10,18 +11,49 @@ repositories {
 dependencies {
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'org.apache.maven.shared:maven-invoker:3.1.0'
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r'
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.10.0.202406032230-r'
+    implementation 'org.slf4j:slf4j-simple:2.0.16'
+    implementation 'info.picocli:picocli:4.7.6'
+    implementation 'org.antlr:antlr4-runtime:4.13.2'
+    implementation 'commons-beanutils:commons-beanutils:1.9.4'
+    implementation 'com.google.guava:guava:33.3.0-jre'
+    implementation 'org.reflections:reflections:0.10.2'
+    implementation 'net.sf.saxon:Saxon-HE:12.5'
+    implementation 'org.checkerframework:checker-qual:3.47.0'
+    implementation('org.apache.maven.doxia:doxia-core:1.12.0') {
+        exclude group: 'com.google.collections', module: 'google-collections'
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+    implementation('org.apache.maven.doxia:doxia-module-xdoc:1.12.0') {
+        exclude group: 'com.google.collections', module: 'google-collections'
+    }
+    compileOnly 'org.apache.ant:ant:1.10.15'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.0'
     testImplementation 'org.mockito:mockito-core:3.12.4'
-    testImplementation 'org.mockito:mockito-inline:3.12.4'
-
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.itsallcode:junit5-system-extensions:1.2.0'
+    testImplementation 'org.junit-pioneer:junit-pioneer:2.2.0'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
+    testImplementation 'com.github.caciocavallosilano:cacio-tta:1.11'
+    testImplementation 'com.google.truth:truth:1.4.4'
+    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.16.2'
+    testImplementation 'commons-io:commons-io:2.16.1'
 }
 
 application {
-    mainClassName = 'com.github.checkstyle.difftool.Main'
+    mainClass = 'com.github.checkstyle.difftool.DiffTool'
+}
+
+shadowJar {
+    archiveBaseName.set('difftool')
+    archiveClassifier.set('')
+    archiveVersion.set('')
+    manifest {
+        attributes 'Main-Class': 'com.github.checkstyle.difftool.DiffTool'
+    }
+    mergeServiceFiles()
+    zip64 true
 }
 
 test {
@@ -33,9 +65,8 @@ test {
 }
 
 tasks.withType(JavaCompile) {
-    //options.release = 21
+    options.release = 21
 }
-
 
 java {
     toolchain {

--- a/diff-java-tool/build.gradle
+++ b/diff-java-tool/build.gradle
@@ -14,11 +14,28 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
+    testImplementation 'org.mockito:mockito-core:3.12.4'
+    testImplementation 'org.mockito:mockito-inline:3.12.4'
+
 }
 
 application {
     mainClassName = 'com.github.checkstyle.difftool.Main'
 }
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+        events "passed", "skipped", "failed"
+    }
+}
+
+tasks.withType(JavaCompile) {
+    //options.release = 21
+}
+
 
 java {
     toolchain {

--- a/diff-java-tool/src/test/java/com/github/checkstyle/difftool/DiffToolTest.java
+++ b/diff-java-tool/src/test/java/com/github/checkstyle/difftool/DiffToolTest.java
@@ -1,0 +1,53 @@
+package com.github.checkstyle.difftool;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DiffToolTest {
+
+    private TestDiffTool testDiffTool;
+
+    @BeforeEach
+    void setUp() {
+        testDiffTool = new TestDiffTool();
+    }
+
+    @Test
+    void testRunGradleExecution() throws IOException, InterruptedException {
+        String srcDir = "/path/to/src";
+        String excludes = "exclude1,exclude2";
+        String checkstyleConfig = "/path/to/checkstyle.xml";
+        String checkstyleVersion = "8.41";
+        String extraRegressionOptions = "-DskipTests=true";
+
+        DiffTool.runGradleExecution(srcDir, excludes, checkstyleConfig, checkstyleVersion, extraRegressionOptions);
+
+        List<String> executedCommands = testDiffTool.getExecutedCommands();
+        assertEquals(2, executedCommands.size());
+        assertEquals("gradle clean", executedCommands.get(0));
+
+        String gradleCheckCommand = executedCommands.get(1);
+        assertTrue(gradleCheckCommand.contains("gradle check"));
+        assertTrue(gradleCheckCommand.contains("-Dcheckstyle.config.location=" + checkstyleConfig));
+        assertTrue(gradleCheckCommand.contains("-Dcheckstyle.excludes=" + excludes));
+        assertTrue(gradleCheckCommand.contains("-Dcheckstyle.version=" + checkstyleVersion));
+        assertTrue(gradleCheckCommand.contains(extraRegressionOptions));
+    }
+
+    private static class TestDiffTool extends DiffTool {
+        private final List<String> executedCommands = new ArrayList<>();
+
+        @Override
+        protected void executeGradleCommand(String command) {
+            executedCommands.add(command);
+        }
+
+        public List<String> getExecutedCommands() {
+            return executedCommands;
+        }
+    }
+}


### PR DESCRIPTION
I have added the logs in the description.

```
piyushkumarsadangi@MacBook-Air javaConv % java -jar /Users/piyushkumarsadangi/Development/test-config/test-configs/diff-java-tool/build/libs/difftool.jar \
--localGitRepo /Users/piyushkumarsadangi/Development/checkstyle \
--baseBranch upstream/master \
--baseConfig /Users/piyushkumarsadangi/Development/test-config/test-configs/diff-java-tool/src/resources/config.xml \
--patchBranch master \
--patchConfig /Users/piyushkumarsadangi/Development/test-config/test-configs/diff-java-tool/src/resources/config.xml \
--listOfProjects /Users/piyushkumarsadangi/Development/test-config/test-configs/diff-java-tool/src/resources/projects-to-test-on.properties
Installing Checkstyle artifact (upstream/master) into local Maven repository ...
Running command: git checkout upstream/master
HEAD is now at bf31b649f Issue #15089: note for windows users on system property syntax
Running command: git log -1 --pretty=MSG:%s%nSHA-1:%H
MSG:Issue #15089: note for windows users on system property syntax
SHA-1:bf31b649f02bc0b68ba9a8fdc79cb0b090db0968
Running command: mvn -e --no-transfer-progress --batch-mode -Pno-validations clean install
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------------------< com.puppycrawl.tools:checkstyle >-------------------
[INFO] Building checkstyle 10.18.2-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:3.4.0:clean (default-clean) @ checkstyle ---
[INFO] Deleting /Users/piyushkumarsadangi/Development/checkstyle/target
[INFO] 
[INFO] --- tidy:1.3.0:check (validate) @ checkstyle ---
[INFO] Tidy is skipped.
[INFO] 
[INFO] --- enforcer:3.5.0:enforce (enforce-maven) @ checkstyle ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] 
[INFO] --- enforcer:3.5.0:enforce (enforce-versions) @ checkstyle ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] Rule 1: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] Rule 2: org.apache.maven.enforcer.rules.dependency.DependencyConvergence passed
[INFO] 
[INFO] --- xml:1.1.0:check-format (default) @ checkstyle ---
[INFO] 
[INFO] --- antlr4:4.13.2:antlr4 (default) @ checkstyle ---
[INFO] ANTLR 4: Processing source directory /Users/piyushkumarsadangi/Development/checkstyle/src/main/resources
[INFO] Processing grammar: com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageLexer.g4
[INFO] Processing grammar: com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser.g4
[INFO] Processing grammar: com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocLexer.g4
[INFO] Processing grammar: com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocParser.g4
[INFO] 
[INFO] --- build-helper:3.6.0:add-source (add-source) @ checkstyle ---
[INFO] Source directory: /Users/piyushkumarsadangi/Development/checkstyle/target/generated-sources/antlr added.
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ checkstyle ---
[INFO] Copying 402 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- build-helper:3.6.0:add-test-source (add-test-source) @ checkstyle ---
[INFO] Test Source directory: /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources added.
[INFO] 
[INFO] --- build-helper:3.6.0:add-test-source (add-it-test-source) @ checkstyle ---
[INFO] Test Source directory: /Users/piyushkumarsadangi/Development/checkstyle/src/it/java added.
[INFO] 
[INFO] --- build-helper:3.6.0:add-test-source (add-it-test-resource) @ checkstyle ---
[INFO] Test Source directory: /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources added.
[INFO] 
[INFO] --- build-helper:3.6.0:add-test-source (add-xdocs-examples-source) @ checkstyle ---
[INFO] Test Source directory: /Users/piyushkumarsadangi/Development/checkstyle/src/xdocs-examples/java added.
[INFO] 
[INFO] --- build-helper:3.6.0:add-test-source (add-xdocs-examples-resource) @ checkstyle ---
[INFO] Test Source directory: /Users/piyushkumarsadangi/Development/checkstyle/src/xdocs-examples/resources added.
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ checkstyle ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 455 source files with javac [debug release 11] to target/classes
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java: Some input files use or override a deprecated API.
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java: Recompile with -Xlint:deprecation for details.
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java: /Users/piyushkumarsadangi/Development/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java uses unchecked or unsafe operations.
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- plexus-component-metadata:2.2.0:generate-metadata (default) @ checkstyle ---
[INFO] Discovered 6 component descriptor(s)
[INFO] 
[INFO] --- exec:3.4.1:java (default) @ checkstyle ---
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ checkstyle ---
[INFO] Copying 2750 resources from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ checkstyle ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 3963 source files with javac [debug release 11] to target/test-classes
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/antlr4/InputAntlr4AstRegressionTrickyYield.java:[8,16] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck1.java:[46,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck1.java:[78,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck1.java:[105,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck1.java:[14,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java:[29,8] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java:[63,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java:[94,14] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java:[116,3] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java:[127,3] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck2.java:[14,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java:[23,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java:[37,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java:[57,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java:[71,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java:[85,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java:[99,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputCorrectAtClauseOrderCheck3.java:[14,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[45,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[75,8] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[94,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[109,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[130,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[160,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[180,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[194,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[210,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[239,14] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[258,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[272,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[286,3] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputFormattedJavaDocTagContinuationIndentation.java:[14,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java:[45,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java:[78,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java:[105,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck1.java:[14,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java:[29,8] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java:[65,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java:[95,14] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java:[117,3] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck2.java:[14,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java:[23,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java:[38,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java:[59,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java:[73,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java:[88,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java:[102,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputIncorrectAtClauseOrderCheck3.java:[14,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[53,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[86,8] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[105,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[122,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[145,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[179,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[199,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[217,12] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[237,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[269,14] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[288,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[309,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[326,3] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputJavaDocTagContinuationIndentation.java:[17,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescription.java:[14,14] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescription.java:[47,14] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescription.java:[65,14] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescriptionSpaceSeq.java:[18,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/InputNonEmptyAtclauseDescriptionSpaceSeq.java:[42,10] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[19,15] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[26,19] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[38,9] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[33,5] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[14,8] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[50,5] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[45,1] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[63,9] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedBadDeprecated.java:[58,2] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedClass.java:[19,8] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedMethod.java:[18,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSpecialCase.java:[21,16] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSpecialCase.java:[26,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSpecialCase.java:[99,11] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSpecialCase.java:[106,11] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/missingdeprecated/InputMissingDeprecatedSpecialCase.java:[113,22] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionIgnoredAnnotations.java:[176,11] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/InputAvoidStarImportAllowClass.java:[111,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/InputAvoidStarImportAllowStaticMember.java:[111,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/InputAvoidStarImportDefault.java:[111,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstarimport/InputAvoidStarImportExcludes.java:[111,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault.java:[112,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault2.java:[112,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault3.java:[112,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault4.java:[114,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault5.java:[113,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportWithChecker.java:[113,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImports.java:[114,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImports2.java:[114,17] deprecated item is not annotated with @Deprecated
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationChainedMethods.java:[10,13] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.Object for a varargs call
  cast to java.lang.Object[] for a non-varargs call and to suppress this warning
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryResourcesNotStrict.java:[59,72] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.nio.file.OpenOption for a varargs call
  cast to java.nio.file.OpenOption[] for a non-varargs call and to suppress this warning
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryWithResourcesStrict.java:[59,69] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.nio.file.OpenOption for a varargs call
  cast to java.nio.file.OpenOption[] for a non-varargs call and to suppress this warning
[WARNING] /Users/piyushkumarsadangi/Development/checkstyle/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/abstractjavadoc/InputAbstractJavadocJavadocTagsWithoutArgs.java:[58,24] deprecated item is not annotated with @Deprecated
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedParenPad.java: Some input files use or override a deprecated API.
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputFormattedParenPad.java: Recompile with -Xlint:deprecation for details.
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/AbstractGuiTestSupport.java: Some input files use unchecked or unsafe operations.
[INFO] /Users/piyushkumarsadangi/Development/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/AbstractGuiTestSupport.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- jacoco:0.8.12:instrument (default-instrument) @ checkstyle ---
[INFO] Skipping JaCoCo execution because property jacoco.skip is set.
[INFO] 
[INFO] --- surefire:3.5.0:test (default-test) @ checkstyle ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- xml:1.1.0:validate (default) @ checkstyle ---
[INFO] 
[INFO] --- jacoco:0.8.12:restore-instrumented-classes (default-restore-instrumented-classes) @ checkstyle ---
[INFO] Skipping JaCoCo execution because property jacoco.skip is set.
[INFO] 
[INFO] --- jar:3.4.2:jar (default-jar) @ checkstyle ---
[INFO] Building jar: /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT.jar
[INFO] 
[INFO] --- jar:3.4.2:test-jar (default) @ checkstyle ---
[INFO] Building jar: /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT-tests.jar
[INFO] 
[INFO] >>> source:3.3.1:test-jar (attach-sources) > generate-sources @ checkstyle >>>
[INFO] 
[INFO] --- tidy:1.3.0:check (validate) @ checkstyle ---
[INFO] Tidy is skipped.
[INFO] 
[INFO] --- enforcer:3.5.0:enforce (enforce-maven) @ checkstyle ---
[INFO] 
[INFO] --- enforcer:3.5.0:enforce (enforce-versions) @ checkstyle ---
[INFO] Rule 2: org.apache.maven.enforcer.rules.dependency.DependencyConvergence passed
[INFO] 
[INFO] --- xml:1.1.0:check-format (default) @ checkstyle ---
[INFO] 
[INFO] --- antlr4:4.13.2:antlr4 (default) @ checkstyle ---
[INFO] No grammars to process
[INFO] ANTLR 4: Processing source directory /Users/piyushkumarsadangi/Development/checkstyle/src/main/resources
[INFO] 
[INFO] --- build-helper:3.6.0:add-source (add-source) @ checkstyle ---
[INFO] Source directory: /Users/piyushkumarsadangi/Development/checkstyle/target/generated-sources/antlr added.
[INFO] 
[INFO] <<< source:3.3.1:test-jar (attach-sources) < generate-sources @ checkstyle <<<
[INFO] 
[INFO] 
[INFO] --- source:3.3.1:test-jar (attach-sources) @ checkstyle ---
[INFO] Building jar: /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT-test-sources.jar
[INFO] 
[INFO] >>> source:3.3.1:jar (attach-sources) > generate-sources @ checkstyle >>>
[INFO] 
[INFO] --- tidy:1.3.0:check (validate) @ checkstyle ---
[INFO] Tidy is skipped.
[INFO] 
[INFO] --- enforcer:3.5.0:enforce (enforce-maven) @ checkstyle ---
[INFO] 
[INFO] --- enforcer:3.5.0:enforce (enforce-versions) @ checkstyle ---
[INFO] Rule 2: org.apache.maven.enforcer.rules.dependency.DependencyConvergence passed
[INFO] 
[INFO] --- xml:1.1.0:check-format (default) @ checkstyle ---
[INFO] 
[INFO] --- antlr4:4.13.2:antlr4 (default) @ checkstyle ---
[INFO] No grammars to process
[INFO] ANTLR 4: Processing source directory /Users/piyushkumarsadangi/Development/checkstyle/src/main/resources
[INFO] 
[INFO] --- build-helper:3.6.0:add-source (add-source) @ checkstyle ---
[INFO] Source directory: /Users/piyushkumarsadangi/Development/checkstyle/target/generated-sources/antlr added.
[INFO] 
[INFO] <<< source:3.3.1:jar (attach-sources) < generate-sources @ checkstyle <<<
[INFO] 
[INFO] 
[INFO] --- source:3.3.1:jar (attach-sources) @ checkstyle ---
[INFO] Building jar: /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT-sources.jar
[INFO] 
[INFO] --- failsafe:3.5.0:integration-test (integration-test) @ checkstyle ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- modernizer:2.9.0:modernizer (modernizer) @ checkstyle ---
[INFO] Skipping modernizer execution!
[INFO] 
[INFO] --- jacoco:0.8.12:check (default-check) @ checkstyle ---
[INFO] Skipping JaCoCo execution because property jacoco.skip is set.
[INFO] 
[INFO] --- failsafe:3.5.0:verify (verify) @ checkstyle ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- antrun:3.1.0:run (ant-phase-verify) @ checkstyle ---
[INFO] Executing tasks
[INFO] Executed tasks
[INFO] 
[INFO] >>> pmd:3.24.0:check (default) > :pmd @ checkstyle >>>
[INFO] 
[INFO] --- pmd:3.24.0:pmd (pmd) @ checkstyle ---
[INFO] Skipping PMD execution
[INFO] 
[INFO] <<< pmd:3.24.0:check (default) < :pmd @ checkstyle <<<
[INFO] 
[INFO] 
[INFO] --- pmd:3.24.0:check (default) @ checkstyle ---
[INFO] Skipping PMD execution
[INFO] 
[INFO] >>> spotbugs:4.8.6.3:check (default) > :spotbugs @ checkstyle >>>
[INFO] 
[INFO] --- spotbugs:4.8.6.3:spotbugs (spotbugs) @ checkstyle ---
[INFO] 
[INFO] <<< spotbugs:4.8.6.3:check (default) < :spotbugs @ checkstyle <<<
[INFO] 
[INFO] 
[INFO] --- spotbugs:4.8.6.3:check (default) @ checkstyle ---
[INFO] Spotbugs plugin skipped
[INFO] 
[INFO] --- forbiddenapis:3.7:check (forbiddenapis-main) @ checkstyle ---
[INFO] Skipping forbidden-apis checks.
[INFO] 
[INFO] --- forbiddenapis:3.7:testCheck (forbiddenapis-test) @ checkstyle ---
[INFO] Skipping forbidden-apis checks.
[INFO] 
[INFO] --- install:3.1.3:install (default-install) @ checkstyle ---
[INFO] Installing /Users/piyushkumarsadangi/Development/checkstyle/pom.xml to /Users/piyushkumarsadangi/.m2/repository/com/puppycrawl/tools/checkstyle/10.18.2-SNAPSHOT/checkstyle-10.18.2-SNAPSHOT.pom
[INFO] Installing /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT.jar to /Users/piyushkumarsadangi/.m2/repository/com/puppycrawl/tools/checkstyle/10.18.2-SNAPSHOT/checkstyle-10.18.2-SNAPSHOT.jar
[INFO] Installing /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT-tests.jar to /Users/piyushkumarsadangi/.m2/repository/com/puppycrawl/tools/checkstyle/10.18.2-SNAPSHOT/checkstyle-10.18.2-SNAPSHOT-tests.jar
[INFO] Installing /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT-test-sources.jar to /Users/piyushkumarsadangi/.m2/repository/com/puppycrawl/tools/checkstyle/10.18.2-SNAPSHOT/checkstyle-10.18.2-SNAPSHOT-test-sources.jar
[INFO] Installing /Users/piyushkumarsadangi/Development/checkstyle/target/checkstyle-10.18.2-SNAPSHOT-sources.jar to /Users/piyushkumarsadangi/.m2/repository/com/puppycrawl/tools/checkstyle/10.18.2-SNAPSHOT/checkstyle-10.18.2-SNAPSHOT-sources.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.735 s
[INFO] Finished at: 2024-09-09T02:49:14+05:30
[INFO] ------------------------------------------------------------------------
Testing Checkstyle started
Cloning git repository 'guava' to repositories/guava folder ...
Cloning into 'repositories/guava'...
remote: Enumerating objects: 431006, done.
remote: Counting objects: 100% (2863/2863), done.
remote: Compressing objects: 100% (361/361), done.
Receiving objects: 100% (431006/431006), 472.81 MiB | 2.35 MiB/s, done.
remote: Total 431006 (delta 2342), reused 2801 (delta 2300), pack-reused 428143 (from 1)
Resolving deltas: 100% (322122/322122), done.
Cloning git repository 'guava' - completed

Running command: git fetch --tags
Resetting git sources to commit 'v28.2'
Running command: git reset --hard refs/tags/v28.2
HEAD is now at a1b3c06876 Reenable Javadoc for the GWT artifact for now.
guava is synchronized
Gradle files verified in /Users/piyushkumarsadangi/Development/javaConv/src/main/checkstyle-tester
Initializing Gradle wrapper in src/main/checkstyle-tester ...

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/piyushkumarsadangi/Development/javaConv/src/main/checkstyle-tester/build.gradle' line: 20

* What went wrong:
A problem occurred evaluating root project 'checkstyle-tester'.
> Could not find method setDestinationDir() for arguments [/Users/piyushkumarsadangi/Development/javaConv/src/main/checkstyle-tester/build/reports/checkstyle] on Report xml of type org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 1s
Error: Error: Gradle command execution failed with exit code 1
java.lang.RuntimeException: Error: Gradle command execution failed with exit code 1
	at com.github.checkstyle.difftool.DiffTool.executeGradleCommand(DiffTool.java:135)
	at com.github.checkstyle.difftool.DiffTool.runGradleExecutionInternal(DiffTool.java:105)
	at com.github.checkstyle.difftool.DiffTool.runGradleExecution(DiffTool.java:86)
	at com.github.checkstyle.difftool.DiffTool.generateCheckstyleReport(DiffTool.java:455)
	at com.github.checkstyle.difftool.DiffTool.launchCheckstyleReport(DiffTool.java:352)
	at com.github.checkstyle.difftool.DiffTool.main(DiffTool.java:58)
```