### PR TITLE
minor: add better explanation as to why parse errors are ignored

### DIFF
--- a/.github/workflows/config.xml
+++ b/.github/workflows/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/.github/workflows/patch-config.xml
+++ b/.github/workflows/patch-config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/Example1/config.xml
+++ b/AbbreviationAsWordInName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/Example2/config.xml
+++ b/AbbreviationAsWordInName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/Example3/config.xml
+++ b/AbbreviationAsWordInName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/Example4/config.xml
+++ b/AbbreviationAsWordInName/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/Example5/config.xml
+++ b/AbbreviationAsWordInName/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/Example6/config.xml
+++ b/AbbreviationAsWordInName/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/Example7/config.xml
+++ b/AbbreviationAsWordInName/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbbreviationAsWordInName/all-examples-in-one/config.xml
+++ b/AbbreviationAsWordInName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbstractClassName/Example1/config.xml
+++ b/AbstractClassName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbstractClassName/Example2/config.xml
+++ b/AbstractClassName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbstractClassName/Example3/config.xml
+++ b/AbstractClassName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbstractClassName/Example4/config.xml
+++ b/AbstractClassName/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AbstractClassName/all-examples-in-one/config.xml
+++ b/AbstractClassName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationLocation/Example1/config.xml
+++ b/AnnotationLocation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationLocation/Example2/config.xml
+++ b/AnnotationLocation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationLocation/Example3/config.xml
+++ b/AnnotationLocation/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationLocation/Example4/config.xml
+++ b/AnnotationLocation/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationLocation/all-examples-in-one/config.xml
+++ b/AnnotationLocation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationOnSameLine/Example1/config.xml
+++ b/AnnotationOnSameLine/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationOnSameLine/Example2/config.xml
+++ b/AnnotationOnSameLine/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationOnSameLine/all-examples-in-one/config.xml
+++ b/AnnotationOnSameLine/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationUseStyle/Example1/config.xml
+++ b/AnnotationUseStyle/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationUseStyle/Example2/config.xml
+++ b/AnnotationUseStyle/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationUseStyle/Example3/config.xml
+++ b/AnnotationUseStyle/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationUseStyle/Example4/config.xml
+++ b/AnnotationUseStyle/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnnotationUseStyle/all-examples-in-one/config.xml
+++ b/AnnotationUseStyle/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnonInnerLength/Example1/config.xml
+++ b/AnonInnerLength/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnonInnerLength/Example2/config.xml
+++ b/AnonInnerLength/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AnonInnerLength/all-examples-in-one/config.xml
+++ b/AnonInnerLength/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ArrayTrailingComma/Example1/config.xml
+++ b/ArrayTrailingComma/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ArrayTrailingComma/Example2/config.xml
+++ b/ArrayTrailingComma/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ArrayTrailingComma/all-examples-in-one/config.xml
+++ b/ArrayTrailingComma/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ArrayTypeStyle/Example1/config.xml
+++ b/ArrayTypeStyle/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ArrayTypeStyle/Example2/config.xml
+++ b/ArrayTypeStyle/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ArrayTypeStyle/all-examples-in-one/config.xml
+++ b/ArrayTypeStyle/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AtclauseOrder/Example1/config.xml
+++ b/AtclauseOrder/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AtclauseOrder/Example2/config.xml
+++ b/AtclauseOrder/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AtclauseOrder/Example3/config.xml
+++ b/AtclauseOrder/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AtclauseOrder/all-examples-in-one/config.xml
+++ b/AtclauseOrder/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidDoubleBraceInitialization/Example1/config.xml
+++ b/AvoidDoubleBraceInitialization/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidDoubleBraceInitialization/all-examples-in-one/config.xml
+++ b/AvoidDoubleBraceInitialization/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidEscapedUnicodeCharacters/Example1/config.xml
+++ b/AvoidEscapedUnicodeCharacters/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidEscapedUnicodeCharacters/Example2/config.xml
+++ b/AvoidEscapedUnicodeCharacters/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidEscapedUnicodeCharacters/Example3/config.xml
+++ b/AvoidEscapedUnicodeCharacters/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidEscapedUnicodeCharacters/Example4/config.xml
+++ b/AvoidEscapedUnicodeCharacters/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidEscapedUnicodeCharacters/Example5/config.xml
+++ b/AvoidEscapedUnicodeCharacters/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidEscapedUnicodeCharacters/all-examples-in-one/config.xml
+++ b/AvoidEscapedUnicodeCharacters/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidInlineConditionals/Example1/config.xml
+++ b/AvoidInlineConditionals/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidInlineConditionals/all-examples-in-one/config.xml
+++ b/AvoidInlineConditionals/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidNestedBlocks/Example1/config.xml
+++ b/AvoidNestedBlocks/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidNestedBlocks/Example2/config.xml
+++ b/AvoidNestedBlocks/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidNestedBlocks/all-examples-in-one/config.xml
+++ b/AvoidNestedBlocks/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidNoArgumentSuperConstructorCall/Example1/config.xml
+++ b/AvoidNoArgumentSuperConstructorCall/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidNoArgumentSuperConstructorCall/all-examples-in-one/config.xml
+++ b/AvoidNoArgumentSuperConstructorCall/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStarImport/Example1/config.xml
+++ b/AvoidStarImport/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStarImport/Example2/config.xml
+++ b/AvoidStarImport/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStarImport/Example3/config.xml
+++ b/AvoidStarImport/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStarImport/Example4/config.xml
+++ b/AvoidStarImport/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStarImport/Example5/config.xml
+++ b/AvoidStarImport/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStarImport/Example6/config.xml
+++ b/AvoidStarImport/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStarImport/all-examples-in-one/config.xml
+++ b/AvoidStarImport/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStaticImport/Example1/config.xml
+++ b/AvoidStaticImport/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStaticImport/Example2/config.xml
+++ b/AvoidStaticImport/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/AvoidStaticImport/all-examples-in-one/config.xml
+++ b/AvoidStaticImport/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/BooleanExpressionComplexity/Example1/config.xml
+++ b/BooleanExpressionComplexity/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/BooleanExpressionComplexity/Example2/config.xml
+++ b/BooleanExpressionComplexity/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/BooleanExpressionComplexity/Example3/config.xml
+++ b/BooleanExpressionComplexity/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/BooleanExpressionComplexity/all-examples-in-one/config.xml
+++ b/BooleanExpressionComplexity/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CatchParameterName/Example1/config.xml
+++ b/CatchParameterName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CatchParameterName/Example2/config.xml
+++ b/CatchParameterName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CatchParameterName/all-examples-in-one/config.xml
+++ b/CatchParameterName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example1/config.xml
+++ b/ClassDataAbstractionCoupling/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example10/config.xml
+++ b/ClassDataAbstractionCoupling/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example11/config.xml
+++ b/ClassDataAbstractionCoupling/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example2/config.xml
+++ b/ClassDataAbstractionCoupling/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example3/config.xml
+++ b/ClassDataAbstractionCoupling/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example4/config.xml
+++ b/ClassDataAbstractionCoupling/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example5/config.xml
+++ b/ClassDataAbstractionCoupling/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example6/config.xml
+++ b/ClassDataAbstractionCoupling/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example7/config.xml
+++ b/ClassDataAbstractionCoupling/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example8/config.xml
+++ b/ClassDataAbstractionCoupling/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/Example9/config.xml
+++ b/ClassDataAbstractionCoupling/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassDataAbstractionCoupling/all-examples-in-one/config.xml
+++ b/ClassDataAbstractionCoupling/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example1/config.xml
+++ b/ClassFanOutComplexity/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example10/config.xml
+++ b/ClassFanOutComplexity/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example11/config.xml
+++ b/ClassFanOutComplexity/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example2/config.xml
+++ b/ClassFanOutComplexity/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example3/config.xml
+++ b/ClassFanOutComplexity/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example4/config.xml
+++ b/ClassFanOutComplexity/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example5/config.xml
+++ b/ClassFanOutComplexity/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example6/config.xml
+++ b/ClassFanOutComplexity/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example7/config.xml
+++ b/ClassFanOutComplexity/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example8/config.xml
+++ b/ClassFanOutComplexity/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/Example9/config.xml
+++ b/ClassFanOutComplexity/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassFanOutComplexity/all-examples-in-one/config.xml
+++ b/ClassFanOutComplexity/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassMemberImpliedModifier/Example1/config.xml
+++ b/ClassMemberImpliedModifier/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassMemberImpliedModifier/all-examples-in-one/config.xml
+++ b/ClassMemberImpliedModifier/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassTypeParameterName/Example1/config.xml
+++ b/ClassTypeParameterName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassTypeParameterName/Example2/config.xml
+++ b/ClassTypeParameterName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassTypeParameterName/Example3/config.xml
+++ b/ClassTypeParameterName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ClassTypeParameterName/all-examples-in-one/config.xml
+++ b/ClassTypeParameterName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example1/config.xml
+++ b/CommentsIndentation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example10/config.xml
+++ b/CommentsIndentation/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example2/config.xml
+++ b/CommentsIndentation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example3/config.xml
+++ b/CommentsIndentation/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example4/config.xml
+++ b/CommentsIndentation/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example5/config.xml
+++ b/CommentsIndentation/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example6/config.xml
+++ b/CommentsIndentation/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example7/config.xml
+++ b/CommentsIndentation/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example8/config.xml
+++ b/CommentsIndentation/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/Example9/config.xml
+++ b/CommentsIndentation/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CommentsIndentation/all-examples-in-one/config.xml
+++ b/CommentsIndentation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ConstantName/Example1/config.xml
+++ b/ConstantName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ConstantName/Example2/config.xml
+++ b/ConstantName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ConstantName/Example3/config.xml
+++ b/ConstantName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ConstantName/all-examples-in-one/config.xml
+++ b/ConstantName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ConstructorsDeclarationGrouping/Example1/config.xml
+++ b/ConstructorsDeclarationGrouping/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ConstructorsDeclarationGrouping/Example2/config.xml
+++ b/ConstructorsDeclarationGrouping/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ConstructorsDeclarationGrouping/all-examples-in-one/config.xml
+++ b/ConstructorsDeclarationGrouping/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CovariantEquals/Example1/config.xml
+++ b/CovariantEquals/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CovariantEquals/Example2/config.xml
+++ b/CovariantEquals/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CovariantEquals/Example3/config.xml
+++ b/CovariantEquals/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CovariantEquals/Example4/config.xml
+++ b/CovariantEquals/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CovariantEquals/all-examples-in-one/config.xml
+++ b/CovariantEquals/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example1/config.xml
+++ b/CustomImportOrder/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example10/config.xml
+++ b/CustomImportOrder/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example11/config.xml
+++ b/CustomImportOrder/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example12/config.xml
+++ b/CustomImportOrder/Example12/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example13/config.xml
+++ b/CustomImportOrder/Example13/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example14/config.xml
+++ b/CustomImportOrder/Example14/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example15/config.xml
+++ b/CustomImportOrder/Example15/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example2/config.xml
+++ b/CustomImportOrder/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example3/config.xml
+++ b/CustomImportOrder/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example4/config.xml
+++ b/CustomImportOrder/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example5/config.xml
+++ b/CustomImportOrder/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example6/config.xml
+++ b/CustomImportOrder/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example7/config.xml
+++ b/CustomImportOrder/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example8/config.xml
+++ b/CustomImportOrder/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/Example9/config.xml
+++ b/CustomImportOrder/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CustomImportOrder/all-examples-in-one/config.xml
+++ b/CustomImportOrder/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CyclomaticComplexity/Example1/config.xml
+++ b/CyclomaticComplexity/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CyclomaticComplexity/Example2/config.xml
+++ b/CyclomaticComplexity/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CyclomaticComplexity/Example3/config.xml
+++ b/CyclomaticComplexity/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/CyclomaticComplexity/all-examples-in-one/config.xml
+++ b/CyclomaticComplexity/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DeclarationOrder/Example1/config.xml
+++ b/DeclarationOrder/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DeclarationOrder/Example2/config.xml
+++ b/DeclarationOrder/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DeclarationOrder/Example3/config.xml
+++ b/DeclarationOrder/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DeclarationOrder/all-examples-in-one/config.xml
+++ b/DeclarationOrder/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DefaultComesLast/Example1/config.xml
+++ b/DefaultComesLast/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DefaultComesLast/Example2/config.xml
+++ b/DefaultComesLast/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DefaultComesLast/all-examples-in-one/config.xml
+++ b/DefaultComesLast/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example1/config.xml
+++ b/DescendantToken/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example10/config.xml
+++ b/DescendantToken/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example11/config.xml
+++ b/DescendantToken/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example12/config.xml
+++ b/DescendantToken/Example12/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example13/config.xml
+++ b/DescendantToken/Example13/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example14/config.xml
+++ b/DescendantToken/Example14/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example15/config.xml
+++ b/DescendantToken/Example15/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example16/config.xml
+++ b/DescendantToken/Example16/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example2/config.xml
+++ b/DescendantToken/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example3/config.xml
+++ b/DescendantToken/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example4/config.xml
+++ b/DescendantToken/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example5/config.xml
+++ b/DescendantToken/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example6/config.xml
+++ b/DescendantToken/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example7/config.xml
+++ b/DescendantToken/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example8/config.xml
+++ b/DescendantToken/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/Example9/config.xml
+++ b/DescendantToken/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DescendantToken/all-examples-in-one/config.xml
+++ b/DescendantToken/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DesignForExtension/Example1/config.xml
+++ b/DesignForExtension/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DesignForExtension/Example2/config.xml
+++ b/DesignForExtension/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DesignForExtension/Example3/config.xml
+++ b/DesignForExtension/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DesignForExtension/Example4/config.xml
+++ b/DesignForExtension/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/DesignForExtension/all-examples-in-one/config.xml
+++ b/DesignForExtension/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyBlock/Example1/config.xml
+++ b/EmptyBlock/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyBlock/Example2/config.xml
+++ b/EmptyBlock/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyBlock/Example3/config.xml
+++ b/EmptyBlock/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyBlock/all-examples-in-one/config.xml
+++ b/EmptyBlock/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyCatchBlock/Example1/config.xml
+++ b/EmptyCatchBlock/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyCatchBlock/Example2/config.xml
+++ b/EmptyCatchBlock/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyCatchBlock/Example3/config.xml
+++ b/EmptyCatchBlock/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyCatchBlock/Example4/config.xml
+++ b/EmptyCatchBlock/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyCatchBlock/Example5/config.xml
+++ b/EmptyCatchBlock/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyCatchBlock/all-examples-in-one/config.xml
+++ b/EmptyCatchBlock/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyForInitializerPad/Example1/config.xml
+++ b/EmptyForInitializerPad/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyForInitializerPad/Example2/config.xml
+++ b/EmptyForInitializerPad/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyForInitializerPad/all-examples-in-one/config.xml
+++ b/EmptyForInitializerPad/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyForIteratorPad/Example1/config.xml
+++ b/EmptyForIteratorPad/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyForIteratorPad/Example2/config.xml
+++ b/EmptyForIteratorPad/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyForIteratorPad/all-examples-in-one/config.xml
+++ b/EmptyForIteratorPad/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyLineSeparator/Example1/config.xml
+++ b/EmptyLineSeparator/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyLineSeparator/Example2/config.xml
+++ b/EmptyLineSeparator/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyLineSeparator/Example3/config.xml
+++ b/EmptyLineSeparator/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyLineSeparator/Example4/config.xml
+++ b/EmptyLineSeparator/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyLineSeparator/Example5/config.xml
+++ b/EmptyLineSeparator/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyLineSeparator/all-examples-in-one/config.xml
+++ b/EmptyLineSeparator/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyStatement/Example1/config.xml
+++ b/EmptyStatement/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EmptyStatement/all-examples-in-one/config.xml
+++ b/EmptyStatement/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EqualsAvoidNull/Example1/config.xml
+++ b/EqualsAvoidNull/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EqualsAvoidNull/Example2/config.xml
+++ b/EqualsAvoidNull/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EqualsAvoidNull/all-examples-in-one/config.xml
+++ b/EqualsAvoidNull/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EqualsHashCode/Example1/config.xml
+++ b/EqualsHashCode/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/EqualsHashCode/all-examples-in-one/config.xml
+++ b/EqualsHashCode/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ExecutableStatementCount/Example1/config.xml
+++ b/ExecutableStatementCount/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ExecutableStatementCount/Example2/config.xml
+++ b/ExecutableStatementCount/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ExecutableStatementCount/Example3/config.xml
+++ b/ExecutableStatementCount/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ExecutableStatementCount/all-examples-in-one/config.xml
+++ b/ExecutableStatementCount/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ExplicitInitialization/Example1/config.xml
+++ b/ExplicitInitialization/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ExplicitInitialization/Example2/config.xml
+++ b/ExplicitInitialization/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ExplicitInitialization/all-examples-in-one/config.xml
+++ b/ExplicitInitialization/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FallThrough/Example1/config.xml
+++ b/FallThrough/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FallThrough/Example2/config.xml
+++ b/FallThrough/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FallThrough/Example3/config.xml
+++ b/FallThrough/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FallThrough/all-examples-in-one/config.xml
+++ b/FallThrough/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalClass/Example1/config.xml
+++ b/FinalClass/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalClass/all-examples-in-one/config.xml
+++ b/FinalClass/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalLocalVariable/Example1/config.xml
+++ b/FinalLocalVariable/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalLocalVariable/Example2/config.xml
+++ b/FinalLocalVariable/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalLocalVariable/Example3/config.xml
+++ b/FinalLocalVariable/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalLocalVariable/Example4/config.xml
+++ b/FinalLocalVariable/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalLocalVariable/all-examples-in-one/config.xml
+++ b/FinalLocalVariable/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalParameters/Example1/config.xml
+++ b/FinalParameters/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalParameters/Example2/config.xml
+++ b/FinalParameters/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalParameters/Example3/config.xml
+++ b/FinalParameters/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalParameters/Example4/config.xml
+++ b/FinalParameters/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/FinalParameters/all-examples-in-one/config.xml
+++ b/FinalParameters/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/GenericWhitespace/Example1/config.xml
+++ b/GenericWhitespace/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/GenericWhitespace/Example2/config.xml
+++ b/GenericWhitespace/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/GenericWhitespace/all-examples-in-one/config.xml
+++ b/GenericWhitespace/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HexLiteralCase/Example1/config.xml
+++ b/HexLiteralCase/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HexLiteralCase/all-examples-in-one/config.xml
+++ b/HexLiteralCase/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/Example1/config.xml
+++ b/HiddenField/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/Example2/config.xml
+++ b/HiddenField/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/Example3/config.xml
+++ b/HiddenField/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/Example4/config.xml
+++ b/HiddenField/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/Example5/config.xml
+++ b/HiddenField/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/Example6/config.xml
+++ b/HiddenField/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/Example7/config.xml
+++ b/HiddenField/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HiddenField/all-examples-in-one/config.xml
+++ b/HiddenField/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HideUtilityClassConstructor/Example1/config.xml
+++ b/HideUtilityClassConstructor/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HideUtilityClassConstructor/Example2/config.xml
+++ b/HideUtilityClassConstructor/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/HideUtilityClassConstructor/all-examples-in-one/config.xml
+++ b/HideUtilityClassConstructor/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalCatch/Example1/config.xml
+++ b/IllegalCatch/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalCatch/Example2/config.xml
+++ b/IllegalCatch/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalCatch/all-examples-in-one/config.xml
+++ b/IllegalCatch/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalIdentifierName/Example1/config.xml
+++ b/IllegalIdentifierName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalIdentifierName/Example2/config.xml
+++ b/IllegalIdentifierName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalIdentifierName/all-examples-in-one/config.xml
+++ b/IllegalIdentifierName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example1/config.xml
+++ b/IllegalImport/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example2/config.xml
+++ b/IllegalImport/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example3/config.xml
+++ b/IllegalImport/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example4/config.xml
+++ b/IllegalImport/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example5/config.xml
+++ b/IllegalImport/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example6/config.xml
+++ b/IllegalImport/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example7/config.xml
+++ b/IllegalImport/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example8/config.xml
+++ b/IllegalImport/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/Example9/config.xml
+++ b/IllegalImport/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalImport/all-examples-in-one/config.xml
+++ b/IllegalImport/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalInstantiation/Example1/config.xml
+++ b/IllegalInstantiation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalInstantiation/Example2/config.xml
+++ b/IllegalInstantiation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalInstantiation/Example3/config.xml
+++ b/IllegalInstantiation/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalInstantiation/all-examples-in-one/config.xml
+++ b/IllegalInstantiation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalThrows/Example1/config.xml
+++ b/IllegalThrows/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalThrows/Example2/config.xml
+++ b/IllegalThrows/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalThrows/Example3/config.xml
+++ b/IllegalThrows/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalThrows/Example4/config.xml
+++ b/IllegalThrows/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalThrows/all-examples-in-one/config.xml
+++ b/IllegalThrows/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalToken/Example1/config.xml
+++ b/IllegalToken/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalToken/Example2/config.xml
+++ b/IllegalToken/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalToken/all-examples-in-one/config.xml
+++ b/IllegalToken/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalTokenText/Example1/config.xml
+++ b/IllegalTokenText/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalTokenText/Example2/config.xml
+++ b/IllegalTokenText/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalTokenText/Example3/config.xml
+++ b/IllegalTokenText/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalTokenText/Example4/config.xml
+++ b/IllegalTokenText/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalTokenText/all-examples-in-one/config.xml
+++ b/IllegalTokenText/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example1/config.xml
+++ b/IllegalType/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example2/config.xml
+++ b/IllegalType/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example3/config.xml
+++ b/IllegalType/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example4/config.xml
+++ b/IllegalType/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example5/config.xml
+++ b/IllegalType/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example6/config.xml
+++ b/IllegalType/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example7/config.xml
+++ b/IllegalType/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example8/config.xml
+++ b/IllegalType/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/Example9/config.xml
+++ b/IllegalType/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/IllegalType/all-examples-in-one/config.xml
+++ b/IllegalType/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example1/config.xml
+++ b/ImportControl/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example10/config.xml
+++ b/ImportControl/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example11/config.xml
+++ b/ImportControl/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example12/config.xml
+++ b/ImportControl/Example12/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example2/config.xml
+++ b/ImportControl/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example4/config.xml
+++ b/ImportControl/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example5/config.xml
+++ b/ImportControl/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example6/config.xml
+++ b/ImportControl/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example7/config.xml
+++ b/ImportControl/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/Example8/config.xml
+++ b/ImportControl/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportControl/all-examples-in-one/config.xml
+++ b/ImportControl/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example1/config.xml
+++ b/ImportOrder/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example10/config.xml
+++ b/ImportOrder/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example11/config.xml
+++ b/ImportOrder/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example12/config.xml
+++ b/ImportOrder/Example12/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example2/config.xml
+++ b/ImportOrder/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example3/config.xml
+++ b/ImportOrder/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example4/config.xml
+++ b/ImportOrder/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example5/config.xml
+++ b/ImportOrder/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example6/config.xml
+++ b/ImportOrder/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example7/config.xml
+++ b/ImportOrder/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example8/config.xml
+++ b/ImportOrder/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/Example9/config.xml
+++ b/ImportOrder/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ImportOrder/all-examples-in-one/config.xml
+++ b/ImportOrder/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Indentation/Example1/config.xml
+++ b/Indentation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Indentation/Example2/config.xml
+++ b/Indentation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Indentation/Example3/config.xml
+++ b/Indentation/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Indentation/Example4/config.xml
+++ b/Indentation/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Indentation/all-examples-in-one/config.xml
+++ b/Indentation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InnerAssignment/Example1/config.xml
+++ b/InnerAssignment/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InnerAssignment/Example2/config.xml
+++ b/InnerAssignment/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InnerAssignment/all-examples-in-one/config.xml
+++ b/InnerAssignment/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InnerTypeLast/Example1/config.xml
+++ b/InnerTypeLast/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InnerTypeLast/all-examples-in-one/config.xml
+++ b/InnerTypeLast/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceIsType/Example1/config.xml
+++ b/InterfaceIsType/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceIsType/Example2/config.xml
+++ b/InterfaceIsType/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceIsType/all-examples-in-one/config.xml
+++ b/InterfaceIsType/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceMemberImpliedModifier/Example1/config.xml
+++ b/InterfaceMemberImpliedModifier/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceMemberImpliedModifier/Example2/config.xml
+++ b/InterfaceMemberImpliedModifier/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceMemberImpliedModifier/all-examples-in-one/config.xml
+++ b/InterfaceMemberImpliedModifier/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceTypeParameterName/Example1/config.xml
+++ b/InterfaceTypeParameterName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceTypeParameterName/Example2/config.xml
+++ b/InterfaceTypeParameterName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InterfaceTypeParameterName/all-examples-in-one/config.xml
+++ b/InterfaceTypeParameterName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InvalidJavadocPosition/Example1/config.xml
+++ b/InvalidJavadocPosition/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/InvalidJavadocPosition/all-examples-in-one/config.xml
+++ b/InvalidJavadocPosition/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavaNCSS/Example1/config.xml
+++ b/JavaNCSS/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavaNCSS/Example2/config.xml
+++ b/JavaNCSS/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavaNCSS/Example3/config.xml
+++ b/JavaNCSS/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavaNCSS/Example4/config.xml
+++ b/JavaNCSS/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavaNCSS/all-examples-in-one/config.xml
+++ b/JavaNCSS/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocBlockTagLocation/Example1/config.xml
+++ b/JavadocBlockTagLocation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocBlockTagLocation/Example2/config.xml
+++ b/JavadocBlockTagLocation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocBlockTagLocation/Example3/config.xml
+++ b/JavadocBlockTagLocation/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocBlockTagLocation/all-examples-in-one/config.xml
+++ b/JavadocBlockTagLocation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocChecks/config.xml
+++ b/JavadocChecks/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocContentLocation/Example1/config.xml
+++ b/JavadocContentLocation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocContentLocation/Example2/config.xml
+++ b/JavadocContentLocation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocContentLocation/all-examples-in-one/config.xml
+++ b/JavadocContentLocation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocLeadingAsteriskAlign/Example1/config.xml
+++ b/JavadocLeadingAsteriskAlign/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocLeadingAsteriskAlign/Example2/config.xml
+++ b/JavadocLeadingAsteriskAlign/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocLeadingAsteriskAlign/Example3/config.xml
+++ b/JavadocLeadingAsteriskAlign/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocLeadingAsteriskAlign/all-examples-in-one/config.xml
+++ b/JavadocLeadingAsteriskAlign/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example1/config.xml
+++ b/JavadocMethod/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example2/config.xml
+++ b/JavadocMethod/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example3/config.xml
+++ b/JavadocMethod/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example4/config.xml
+++ b/JavadocMethod/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example5/config.xml
+++ b/JavadocMethod/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example6/config.xml
+++ b/JavadocMethod/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example7/config.xml
+++ b/JavadocMethod/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/Example8/config.xml
+++ b/JavadocMethod/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMethod/all-examples-in-one/config.xml
+++ b/JavadocMethod/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMissingLeadingAsterisk/Example1/config.xml
+++ b/JavadocMissingLeadingAsterisk/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMissingLeadingAsterisk/all-examples-in-one/config.xml
+++ b/JavadocMissingLeadingAsterisk/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMissingWhitespaceAfterAsterisk/Example1/config.xml
+++ b/JavadocMissingWhitespaceAfterAsterisk/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocMissingWhitespaceAfterAsterisk/all-examples-in-one/config.xml
+++ b/JavadocMissingWhitespaceAfterAsterisk/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocParagraph/Example1/config.xml
+++ b/JavadocParagraph/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocParagraph/Example2/config.xml
+++ b/JavadocParagraph/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocParagraph/Example3/config.xml
+++ b/JavadocParagraph/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocParagraph/Example4/config.xml
+++ b/JavadocParagraph/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocParagraph/all-examples-in-one/config.xml
+++ b/JavadocParagraph/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocStyle/Example1/config.xml
+++ b/JavadocStyle/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocStyle/Example2/config.xml
+++ b/JavadocStyle/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocStyle/Example3/config.xml
+++ b/JavadocStyle/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocStyle/Example4/config.xml
+++ b/JavadocStyle/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocStyle/Example5/config.xml
+++ b/JavadocStyle/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocStyle/Example6/config.xml
+++ b/JavadocStyle/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocStyle/all-examples-in-one/config.xml
+++ b/JavadocStyle/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocTagContinuationIndentation/Example1/config.xml
+++ b/JavadocTagContinuationIndentation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocTagContinuationIndentation/Example2/config.xml
+++ b/JavadocTagContinuationIndentation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocTagContinuationIndentation/Example3/config.xml
+++ b/JavadocTagContinuationIndentation/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocTagContinuationIndentation/Example4/config.xml
+++ b/JavadocTagContinuationIndentation/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocTagContinuationIndentation/all-examples-in-one/config.xml
+++ b/JavadocTagContinuationIndentation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example1/config.xml
+++ b/JavadocType/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example2/config.xml
+++ b/JavadocType/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example3/config.xml
+++ b/JavadocType/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example4/config.xml
+++ b/JavadocType/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example5/config.xml
+++ b/JavadocType/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example6/config.xml
+++ b/JavadocType/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example7/config.xml
+++ b/JavadocType/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/Example8/config.xml
+++ b/JavadocType/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocType/all-examples-in-one/config.xml
+++ b/JavadocType/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocVariable/Example1/config.xml
+++ b/JavadocVariable/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocVariable/Example2/config.xml
+++ b/JavadocVariable/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocVariable/Example3/config.xml
+++ b/JavadocVariable/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocVariable/Example4/config.xml
+++ b/JavadocVariable/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocVariable/Example5/config.xml
+++ b/JavadocVariable/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/JavadocVariable/all-examples-in-one/config.xml
+++ b/JavadocVariable/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LambdaBodyLength/Example1/config.xml
+++ b/LambdaBodyLength/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LambdaBodyLength/Example2/config.xml
+++ b/LambdaBodyLength/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LambdaBodyLength/all-examples-in-one/config.xml
+++ b/LambdaBodyLength/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LambdaParameterName/Example1/config.xml
+++ b/LambdaParameterName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LambdaParameterName/Example2/config.xml
+++ b/LambdaParameterName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LambdaParameterName/all-examples-in-one/config.xml
+++ b/LambdaParameterName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LeftCurly/Example1/config.xml
+++ b/LeftCurly/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LeftCurly/Example2/config.xml
+++ b/LeftCurly/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LeftCurly/Example3/config.xml
+++ b/LeftCurly/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LeftCurly/Example4/config.xml
+++ b/LeftCurly/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LeftCurly/all-examples-in-one/config.xml
+++ b/LeftCurly/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalFinalVariableName/Example1/config.xml
+++ b/LocalFinalVariableName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalFinalVariableName/Example2/config.xml
+++ b/LocalFinalVariableName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalFinalVariableName/Example3/config.xml
+++ b/LocalFinalVariableName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalFinalVariableName/all-examples-in-one/config.xml
+++ b/LocalFinalVariableName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalVariableName/Example1/config.xml
+++ b/LocalVariableName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalVariableName/Example2/config.xml
+++ b/LocalVariableName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalVariableName/Example3/config.xml
+++ b/LocalVariableName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalVariableName/Example4/config.xml
+++ b/LocalVariableName/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalVariableName/Example5/config.xml
+++ b/LocalVariableName/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/LocalVariableName/all-examples-in-one/config.xml
+++ b/LocalVariableName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MagicNumber/Example1/config.xml
+++ b/MagicNumber/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MagicNumber/Example2/config.xml
+++ b/MagicNumber/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MagicNumber/Example3/config.xml
+++ b/MagicNumber/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MagicNumber/Example4/config.xml
+++ b/MagicNumber/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MagicNumber/Example5/config.xml
+++ b/MagicNumber/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MagicNumber/Example6/config.xml
+++ b/MagicNumber/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MagicNumber/all-examples-in-one/config.xml
+++ b/MagicNumber/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MatchXpath/Example1/config.xml
+++ b/MatchXpath/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MatchXpath/Example2/config.xml
+++ b/MatchXpath/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MatchXpath/Example3/config.xml
+++ b/MatchXpath/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MatchXpath/Example4/config.xml
+++ b/MatchXpath/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MatchXpath/Example5/config.xml
+++ b/MatchXpath/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MatchXpath/all-examples-in-one/config.xml
+++ b/MatchXpath/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MemberName/Example1/config.xml
+++ b/MemberName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MemberName/Example2/config.xml
+++ b/MemberName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MemberName/Example3/config.xml
+++ b/MemberName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MemberName/all-examples-in-one/config.xml
+++ b/MemberName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodCount/Example1/config.xml
+++ b/MethodCount/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodCount/Example2/config.xml
+++ b/MethodCount/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodCount/Example3/config.xml
+++ b/MethodCount/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodCount/all-examples-in-one/config.xml
+++ b/MethodCount/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodLength/Example1/config.xml
+++ b/MethodLength/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodLength/Example2/config.xml
+++ b/MethodLength/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodLength/Example3/config.xml
+++ b/MethodLength/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodLength/all-examples-in-one/config.xml
+++ b/MethodLength/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/Example1/config.xml
+++ b/MethodName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/Example2/config.xml
+++ b/MethodName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/Example3/config.xml
+++ b/MethodName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/Example4/config.xml
+++ b/MethodName/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/Example5/config.xml
+++ b/MethodName/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/Example6/config.xml
+++ b/MethodName/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/Example7/config.xml
+++ b/MethodName/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodName/all-examples-in-one/config.xml
+++ b/MethodName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodParamPad/Example1/config.xml
+++ b/MethodParamPad/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodParamPad/Example2/config.xml
+++ b/MethodParamPad/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodParamPad/all-examples-in-one/config.xml
+++ b/MethodParamPad/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodTypeParameterName/Example1/config.xml
+++ b/MethodTypeParameterName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodTypeParameterName/Example2/config.xml
+++ b/MethodTypeParameterName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MethodTypeParameterName/all-examples-in-one/config.xml
+++ b/MethodTypeParameterName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingCtor/Example1/config.xml
+++ b/MissingCtor/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingCtor/all-examples-in-one/config.xml
+++ b/MissingCtor/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingDeprecated/Example1/config.xml
+++ b/MissingDeprecated/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingDeprecated/Example2/config.xml
+++ b/MissingDeprecated/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingDeprecated/all-examples-in-one/config.xml
+++ b/MissingDeprecated/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/Example1/config.xml
+++ b/MissingJavadocMethod/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/Example2/config.xml
+++ b/MissingJavadocMethod/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/Example3/config.xml
+++ b/MissingJavadocMethod/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/Example4/config.xml
+++ b/MissingJavadocMethod/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/Example5/config.xml
+++ b/MissingJavadocMethod/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/Example6/config.xml
+++ b/MissingJavadocMethod/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/Example7/config.xml
+++ b/MissingJavadocMethod/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocMethod/all-examples-in-one/config.xml
+++ b/MissingJavadocMethod/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocPackage/Example1/config.xml
+++ b/MissingJavadocPackage/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocPackage/all-examples-in-one/config.xml
+++ b/MissingJavadocPackage/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocType/Example1/config.xml
+++ b/MissingJavadocType/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocType/Example2/config.xml
+++ b/MissingJavadocType/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocType/Example3/config.xml
+++ b/MissingJavadocType/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocType/Example4/config.xml
+++ b/MissingJavadocType/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocType/Example5/config.xml
+++ b/MissingJavadocType/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingJavadocType/all-examples-in-one/config.xml
+++ b/MissingJavadocType/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingNullCaseInSwitch/Example1/config.xml
+++ b/MissingNullCaseInSwitch/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingNullCaseInSwitch/all-examples-in-one/config.xml
+++ b/MissingNullCaseInSwitch/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingOverride/Example1/config.xml
+++ b/MissingOverride/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingOverride/Example2/config.xml
+++ b/MissingOverride/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingOverride/all-examples-in-one/config.xml
+++ b/MissingOverride/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingSwitchDefault/Example1/config.xml
+++ b/MissingSwitchDefault/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingSwitchDefault/Example2/config.xml
+++ b/MissingSwitchDefault/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingSwitchDefault/Example3/config.xml
+++ b/MissingSwitchDefault/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MissingSwitchDefault/all-examples-in-one/config.xml
+++ b/MissingSwitchDefault/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ModifiedControlVariable/Example1/config.xml
+++ b/ModifiedControlVariable/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ModifiedControlVariable/Example2/config.xml
+++ b/ModifiedControlVariable/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ModifiedControlVariable/all-examples-in-one/config.xml
+++ b/ModifiedControlVariable/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ModifierOrder/Example1/config.xml
+++ b/ModifierOrder/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ModifierOrder/all-examples-in-one/config.xml
+++ b/ModifierOrder/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MultipleStringLiterals/Example1/config.xml
+++ b/MultipleStringLiterals/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MultipleStringLiterals/Example2/config.xml
+++ b/MultipleStringLiterals/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MultipleStringLiterals/Example3/config.xml
+++ b/MultipleStringLiterals/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MultipleStringLiterals/Example4/config.xml
+++ b/MultipleStringLiterals/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MultipleStringLiterals/all-examples-in-one/config.xml
+++ b/MultipleStringLiterals/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MultipleVariableDeclarations/Example1/config.xml
+++ b/MultipleVariableDeclarations/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MultipleVariableDeclarations/all-examples-in-one/config.xml
+++ b/MultipleVariableDeclarations/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MutableException/Example1/config.xml
+++ b/MutableException/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MutableException/Example2/config.xml
+++ b/MutableException/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MutableException/Example3/config.xml
+++ b/MutableException/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/MutableException/all-examples-in-one/config.xml
+++ b/MutableException/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NPathComplexity/Example1/config.xml
+++ b/NPathComplexity/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NPathComplexity/Example2/config.xml
+++ b/NPathComplexity/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NPathComplexity/all-examples-in-one/config.xml
+++ b/NPathComplexity/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NeedBraces/Example1/config.xml
+++ b/NeedBraces/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NeedBraces/Example2/config.xml
+++ b/NeedBraces/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NeedBraces/Example3/config.xml
+++ b/NeedBraces/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NeedBraces/Example4/config.xml
+++ b/NeedBraces/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NeedBraces/Example5/config.xml
+++ b/NeedBraces/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NeedBraces/Example6/config.xml
+++ b/NeedBraces/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NeedBraces/all-examples-in-one/config.xml
+++ b/NeedBraces/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedForDepth/Example1/config.xml
+++ b/NestedForDepth/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedForDepth/Example2/config.xml
+++ b/NestedForDepth/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedForDepth/all-examples-in-one/config.xml
+++ b/NestedForDepth/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedIfDepth/Example1/config.xml
+++ b/NestedIfDepth/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedIfDepth/Example2/config.xml
+++ b/NestedIfDepth/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedIfDepth/Example3/config.xml
+++ b/NestedIfDepth/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedIfDepth/Example4/config.xml
+++ b/NestedIfDepth/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedIfDepth/all-examples-in-one/config.xml
+++ b/NestedIfDepth/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedTryDepth/Example1/config.xml
+++ b/NestedTryDepth/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedTryDepth/Example2/config.xml
+++ b/NestedTryDepth/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedTryDepth/Example3/config.xml
+++ b/NestedTryDepth/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedTryDepth/Example4/config.xml
+++ b/NestedTryDepth/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedTryDepth/Example5/config.xml
+++ b/NestedTryDepth/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NestedTryDepth/all-examples-in-one/config.xml
+++ b/NestedTryDepth/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoArrayTrailingComma/Example1/config.xml
+++ b/NoArrayTrailingComma/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoArrayTrailingComma/all-examples-in-one/config.xml
+++ b/NoArrayTrailingComma/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoClone/Example1/config.xml
+++ b/NoClone/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoClone/all-examples-in-one/config.xml
+++ b/NoClone/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoCodeInFile/Example1/config.xml
+++ b/NoCodeInFile/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoCodeInFile/Example2/config.xml
+++ b/NoCodeInFile/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoCodeInFile/all-examples-in-one/config.xml
+++ b/NoCodeInFile/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoEnumTrailingComma/Example1/config.xml
+++ b/NoEnumTrailingComma/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoEnumTrailingComma/all-examples-in-one/config.xml
+++ b/NoEnumTrailingComma/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoFinalizer/Example1/config.xml
+++ b/NoFinalizer/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoFinalizer/all-examples-in-one/config.xml
+++ b/NoFinalizer/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoLineWrap/Example1/config.xml
+++ b/NoLineWrap/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoLineWrap/Example2/config.xml
+++ b/NoLineWrap/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoLineWrap/Example3/config.xml
+++ b/NoLineWrap/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoLineWrap/Example4/config.xml
+++ b/NoLineWrap/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoLineWrap/Example5/config.xml
+++ b/NoLineWrap/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoLineWrap/all-examples-in-one/config.xml
+++ b/NoLineWrap/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceAfter/Example1/config.xml
+++ b/NoWhitespaceAfter/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceAfter/Example2/config.xml
+++ b/NoWhitespaceAfter/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceAfter/all-examples-in-one/config.xml
+++ b/NoWhitespaceAfter/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceBefore/Example1/config.xml
+++ b/NoWhitespaceBefore/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceBefore/Example2/config.xml
+++ b/NoWhitespaceBefore/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceBefore/Example3/config.xml
+++ b/NoWhitespaceBefore/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceBefore/Example4/config.xml
+++ b/NoWhitespaceBefore/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceBefore/all-examples-in-one/config.xml
+++ b/NoWhitespaceBefore/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceBeforeCaseDefaultColon/Example1/config.xml
+++ b/NoWhitespaceBeforeCaseDefaultColon/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NoWhitespaceBeforeCaseDefaultColon/all-examples-in-one/config.xml
+++ b/NoWhitespaceBeforeCaseDefaultColon/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NonEmptyAtclauseDescription/Example1/config.xml
+++ b/NonEmptyAtclauseDescription/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NonEmptyAtclauseDescription/Example2/config.xml
+++ b/NonEmptyAtclauseDescription/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/NonEmptyAtclauseDescription/all-examples-in-one/config.xml
+++ b/NonEmptyAtclauseDescription/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OneStatementPerLine/Example1/config.xml
+++ b/OneStatementPerLine/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OneStatementPerLine/Example2/config.xml
+++ b/OneStatementPerLine/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OneStatementPerLine/all-examples-in-one/config.xml
+++ b/OneStatementPerLine/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OneTopLevelClass/Example1/config.xml
+++ b/OneTopLevelClass/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OneTopLevelClass/Example2/config.xml
+++ b/OneTopLevelClass/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OneTopLevelClass/Example3/config.xml
+++ b/OneTopLevelClass/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OneTopLevelClass/all-examples-in-one/config.xml
+++ b/OneTopLevelClass/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OperatorWrap/Example1/config.xml
+++ b/OperatorWrap/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OperatorWrap/Example2/config.xml
+++ b/OperatorWrap/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OperatorWrap/all-examples-in-one/config.xml
+++ b/OperatorWrap/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeFilename/Example1/config.xml
+++ b/OuterTypeFilename/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeFilename/Example2/config.xml
+++ b/OuterTypeFilename/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeFilename/Example3/config.xml
+++ b/OuterTypeFilename/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeFilename/Example4/config.xml
+++ b/OuterTypeFilename/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeFilename/Example5/config.xml
+++ b/OuterTypeFilename/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeFilename/all-examples-in-one/config.xml
+++ b/OuterTypeFilename/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeNumber/Example1/config.xml
+++ b/OuterTypeNumber/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeNumber/Example2/config.xml
+++ b/OuterTypeNumber/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OuterTypeNumber/all-examples-in-one/config.xml
+++ b/OuterTypeNumber/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OverloadMethodsDeclarationOrder/Example1/config.xml
+++ b/OverloadMethodsDeclarationOrder/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OverloadMethodsDeclarationOrder/Example2/config.xml
+++ b/OverloadMethodsDeclarationOrder/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/OverloadMethodsDeclarationOrder/all-examples-in-one/config.xml
+++ b/OverloadMethodsDeclarationOrder/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageAnnotation/Example1/config.xml
+++ b/PackageAnnotation/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageAnnotation/Example2/config.xml
+++ b/PackageAnnotation/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageAnnotation/all-examples-in-one/config.xml
+++ b/PackageAnnotation/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageDeclaration/Example1/config.xml
+++ b/PackageDeclaration/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageDeclaration/Example2/config.xml
+++ b/PackageDeclaration/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageDeclaration/all-examples-in-one/config.xml
+++ b/PackageDeclaration/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageName/Example1/config.xml
+++ b/PackageName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageName/Example2/config.xml
+++ b/PackageName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PackageName/all-examples-in-one/config.xml
+++ b/PackageName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterAssignment/Example1/config.xml
+++ b/ParameterAssignment/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterAssignment/all-examples-in-one/config.xml
+++ b/ParameterAssignment/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterName/Example1/config.xml
+++ b/ParameterName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterName/Example2/config.xml
+++ b/ParameterName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterName/Example3/config.xml
+++ b/ParameterName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterName/Example4/config.xml
+++ b/ParameterName/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterName/Example5/config.xml
+++ b/ParameterName/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterName/all-examples-in-one/config.xml
+++ b/ParameterName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterNumber/Example1/config.xml
+++ b/ParameterNumber/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterNumber/Example2/config.xml
+++ b/ParameterNumber/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterNumber/Example3/config.xml
+++ b/ParameterNumber/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterNumber/Example4/config.xml
+++ b/ParameterNumber/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParameterNumber/all-examples-in-one/config.xml
+++ b/ParameterNumber/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParenPad/Example1/config.xml
+++ b/ParenPad/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParenPad/Example2/config.xml
+++ b/ParenPad/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ParenPad/all-examples-in-one/config.xml
+++ b/ParenPad/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PatternVariableAssignment/Example1/config.xml
+++ b/PatternVariableAssignment/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PatternVariableAssignment/all-examples-in-one/config.xml
+++ b/PatternVariableAssignment/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PatternVariableName/Example1/config.xml
+++ b/PatternVariableName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PatternVariableName/Example2/config.xml
+++ b/PatternVariableName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PatternVariableName/Example3/config.xml
+++ b/PatternVariableName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PatternVariableName/Example4/config.xml
+++ b/PatternVariableName/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/PatternVariableName/all-examples-in-one/config.xml
+++ b/PatternVariableName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordComponentName/Example1/config.xml
+++ b/RecordComponentName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordComponentName/Example2/config.xml
+++ b/RecordComponentName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordComponentName/all-examples-in-one/config.xml
+++ b/RecordComponentName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordComponentNumber/Example1/config.xml
+++ b/RecordComponentNumber/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordComponentNumber/Example2/config.xml
+++ b/RecordComponentNumber/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordComponentNumber/Example3/config.xml
+++ b/RecordComponentNumber/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordComponentNumber/all-examples-in-one/config.xml
+++ b/RecordComponentNumber/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordTypeParameterName/Example1/config.xml
+++ b/RecordTypeParameterName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordTypeParameterName/Example2/config.xml
+++ b/RecordTypeParameterName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RecordTypeParameterName/all-examples-in-one/config.xml
+++ b/RecordTypeParameterName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RedundantImport/Example1/config.xml
+++ b/RedundantImport/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RedundantImport/all-examples-in-one/config.xml
+++ b/RedundantImport/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RedundantModifier/Example1/config.xml
+++ b/RedundantModifier/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RedundantModifier/Example2/config.xml
+++ b/RedundantModifier/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RedundantModifier/Example3/config.xml
+++ b/RedundantModifier/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RedundantModifier/all-examples-in-one/config.xml
+++ b/RedundantModifier/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example0/config.xml
+++ b/Regexp/Example0/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example1/config.xml
+++ b/Regexp/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example10/config.xml
+++ b/Regexp/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example11/config.xml
+++ b/Regexp/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example12/config.xml
+++ b/Regexp/Example12/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example13/config.xml
+++ b/Regexp/Example13/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example2/config.xml
+++ b/Regexp/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example3/config.xml
+++ b/Regexp/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example4/config.xml
+++ b/Regexp/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example5/config.xml
+++ b/Regexp/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example6/config.xml
+++ b/Regexp/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example7/config.xml
+++ b/Regexp/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example8/config.xml
+++ b/Regexp/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/Example9/config.xml
+++ b/Regexp/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/Regexp/all-examples-in-one/config.xml
+++ b/Regexp/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/Example1/config.xml
+++ b/RegexpSinglelineJava/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/Example2/config.xml
+++ b/RegexpSinglelineJava/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/Example3/config.xml
+++ b/RegexpSinglelineJava/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/Example4/config.xml
+++ b/RegexpSinglelineJava/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/Example5/config.xml
+++ b/RegexpSinglelineJava/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/Example6/config.xml
+++ b/RegexpSinglelineJava/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/Example7/config.xml
+++ b/RegexpSinglelineJava/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RegexpSinglelineJava/all-examples-in-one/config.xml
+++ b/RegexpSinglelineJava/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireEmptyLineBeforeBlockTagGroup/Example1/config.xml
+++ b/RequireEmptyLineBeforeBlockTagGroup/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireEmptyLineBeforeBlockTagGroup/all-examples-in-one/config.xml
+++ b/RequireEmptyLineBeforeBlockTagGroup/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireThis/Example1/config.xml
+++ b/RequireThis/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireThis/Example2/config.xml
+++ b/RequireThis/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireThis/Example3/config.xml
+++ b/RequireThis/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireThis/Example4/config.xml
+++ b/RequireThis/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireThis/Example5/config.xml
+++ b/RequireThis/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireThis/Example6/config.xml
+++ b/RequireThis/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RequireThis/all-examples-in-one/config.xml
+++ b/RequireThis/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ReturnCount/Example1/config.xml
+++ b/ReturnCount/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ReturnCount/Example2/config.xml
+++ b/ReturnCount/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ReturnCount/Example3/config.xml
+++ b/ReturnCount/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ReturnCount/Example4/config.xml
+++ b/ReturnCount/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ReturnCount/Example5/config.xml
+++ b/ReturnCount/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ReturnCount/all-examples-in-one/config.xml
+++ b/ReturnCount/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RightCurly/Example1/config.xml
+++ b/RightCurly/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RightCurly/Example2/config.xml
+++ b/RightCurly/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RightCurly/Example3/config.xml
+++ b/RightCurly/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RightCurly/Example4/config.xml
+++ b/RightCurly/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RightCurly/Example5/config.xml
+++ b/RightCurly/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/RightCurly/all-examples-in-one/config.xml
+++ b/RightCurly/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SealedShouldHavePermitsList/Example1/config.xml
+++ b/SealedShouldHavePermitsList/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SealedShouldHavePermitsList/all-examples-in-one/config.xml
+++ b/SealedShouldHavePermitsList/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SeparatorWrap/Example1/config.xml
+++ b/SeparatorWrap/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SeparatorWrap/Example2/config.xml
+++ b/SeparatorWrap/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SeparatorWrap/Example3/config.xml
+++ b/SeparatorWrap/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SeparatorWrap/all-examples-in-one/config.xml
+++ b/SeparatorWrap/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SimplifyBooleanExpression/Example1/config.xml
+++ b/SimplifyBooleanExpression/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SimplifyBooleanExpression/all-examples-in-one/config.xml
+++ b/SimplifyBooleanExpression/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SimplifyBooleanReturn/Example1/config.xml
+++ b/SimplifyBooleanReturn/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SimplifyBooleanReturn/all-examples-in-one/config.xml
+++ b/SimplifyBooleanReturn/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleLineJavadoc/Example1/config.xml
+++ b/SingleLineJavadoc/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleLineJavadoc/Example2/config.xml
+++ b/SingleLineJavadoc/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleLineJavadoc/Example3/config.xml
+++ b/SingleLineJavadoc/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleLineJavadoc/Example4/config.xml
+++ b/SingleLineJavadoc/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleLineJavadoc/all-examples-in-one/config.xml
+++ b/SingleLineJavadoc/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleSpaceSeparator/Example1/config.xml
+++ b/SingleSpaceSeparator/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleSpaceSeparator/Example2/config.xml
+++ b/SingleSpaceSeparator/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SingleSpaceSeparator/all-examples-in-one/config.xml
+++ b/SingleSpaceSeparator/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/StaticVariableName/Example1/config.xml
+++ b/StaticVariableName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/StaticVariableName/Example2/config.xml
+++ b/StaticVariableName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/StaticVariableName/Example3/config.xml
+++ b/StaticVariableName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/StaticVariableName/all-examples-in-one/config.xml
+++ b/StaticVariableName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/StringLiteralEquality/Example1/config.xml
+++ b/StringLiteralEquality/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/StringLiteralEquality/all-examples-in-one/config.xml
+++ b/StringLiteralEquality/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SummaryJavadoc/Example1/config.xml
+++ b/SummaryJavadoc/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SummaryJavadoc/Example2/config.xml
+++ b/SummaryJavadoc/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SummaryJavadoc/Example3/config.xml
+++ b/SummaryJavadoc/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SummaryJavadoc/Example4/config.xml
+++ b/SummaryJavadoc/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SummaryJavadoc/Example5/config.xml
+++ b/SummaryJavadoc/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SummaryJavadoc/Example6/config.xml
+++ b/SummaryJavadoc/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SummaryJavadoc/all-examples-in-one/config.xml
+++ b/SummaryJavadoc/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SuperClone/Example1/config.xml
+++ b/SuperClone/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SuperClone/all-examples-in-one/config.xml
+++ b/SuperClone/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SuperFinalize/Example1/config.xml
+++ b/SuperFinalize/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SuperFinalize/all-examples-in-one/config.xml
+++ b/SuperFinalize/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SuppressWarnings/Example1/config.xml
+++ b/SuppressWarnings/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SuppressWarnings/Example2/config.xml
+++ b/SuppressWarnings/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/SuppressWarnings/all-examples-in-one/config.xml
+++ b/SuppressWarnings/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ThrowsCount/Example1/config.xml
+++ b/ThrowsCount/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ThrowsCount/Example2/config.xml
+++ b/ThrowsCount/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ThrowsCount/Example3/config.xml
+++ b/ThrowsCount/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/ThrowsCount/all-examples-in-one/config.xml
+++ b/ThrowsCount/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TodoComment/Example1/config.xml
+++ b/TodoComment/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TodoComment/Example2/config.xml
+++ b/TodoComment/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TodoComment/all-examples-in-one/config.xml
+++ b/TodoComment/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TrailingComment/Example1/config.xml
+++ b/TrailingComment/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TrailingComment/Example2/config.xml
+++ b/TrailingComment/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TrailingComment/Example3/config.xml
+++ b/TrailingComment/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TrailingComment/Example4/config.xml
+++ b/TrailingComment/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TrailingComment/Example5/config.xml
+++ b/TrailingComment/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TrailingComment/Example6/config.xml
+++ b/TrailingComment/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TrailingComment/all-examples-in-one/config.xml
+++ b/TrailingComment/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypeName/Example1/config.xml
+++ b/TypeName/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypeName/Example2/config.xml
+++ b/TypeName/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypeName/Example3/config.xml
+++ b/TypeName/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypeName/Example4/config.xml
+++ b/TypeName/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypeName/all-examples-in-one/config.xml
+++ b/TypeName/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypecastParenPad/Example1/config.xml
+++ b/TypecastParenPad/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypecastParenPad/Example2/config.xml
+++ b/TypecastParenPad/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/TypecastParenPad/all-examples-in-one/config.xml
+++ b/TypecastParenPad/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UncommentedMain/Example1/config.xml
+++ b/UncommentedMain/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UncommentedMain/Example2/config.xml
+++ b/UncommentedMain/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UncommentedMain/all-examples-in-one/config.xml
+++ b/UncommentedMain/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessaryNullCheckWithInstanceOf/Example1/config.xml
+++ b/UnnecessaryNullCheckWithInstanceOf/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessaryNullCheckWithInstanceOf/all-examples-in-one/config.xml
+++ b/UnnecessaryNullCheckWithInstanceOf/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessaryParentheses/Example1/config.xml
+++ b/UnnecessaryParentheses/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessaryParentheses/Example2/config.xml
+++ b/UnnecessaryParentheses/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessaryParentheses/Example3/config.xml
+++ b/UnnecessaryParentheses/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessaryParentheses/all-examples-in-one/config.xml
+++ b/UnnecessaryParentheses/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/Example1/config.xml
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/Example2/config.xml
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/all-examples-in-one/config.xml
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonAfterTypeMemberDeclaration/Example1/config.xml
+++ b/UnnecessarySemicolonAfterTypeMemberDeclaration/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonAfterTypeMemberDeclaration/all-examples-in-one/config.xml
+++ b/UnnecessarySemicolonAfterTypeMemberDeclaration/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonInEnumeration/Example1/config.xml
+++ b/UnnecessarySemicolonInEnumeration/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonInEnumeration/Example2/config.xml
+++ b/UnnecessarySemicolonInEnumeration/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonInEnumeration/all-examples-in-one/config.xml
+++ b/UnnecessarySemicolonInEnumeration/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonInTryWithResources/Example1/config.xml
+++ b/UnnecessarySemicolonInTryWithResources/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonInTryWithResources/Example2/config.xml
+++ b/UnnecessarySemicolonInTryWithResources/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnnecessarySemicolonInTryWithResources/all-examples-in-one/config.xml
+++ b/UnnecessarySemicolonInTryWithResources/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedCatchParameterShouldBeUnnamed/Example1/config.xml
+++ b/UnusedCatchParameterShouldBeUnnamed/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedCatchParameterShouldBeUnnamed/all-examples-in-one/config.xml
+++ b/UnusedCatchParameterShouldBeUnnamed/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedImports/Example1/config.xml
+++ b/UnusedImports/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedImports/Example2/config.xml
+++ b/UnusedImports/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedImports/all-examples-in-one/config.xml
+++ b/UnusedImports/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedLambdaParameterShouldBeUnnamed/Example1/config.xml
+++ b/UnusedLambdaParameterShouldBeUnnamed/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedLambdaParameterShouldBeUnnamed/all-examples-in-one/config.xml
+++ b/UnusedLambdaParameterShouldBeUnnamed/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedLocalVariable/Example1/config.xml
+++ b/UnusedLocalVariable/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedLocalVariable/Example2/config.xml
+++ b/UnusedLocalVariable/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UnusedLocalVariable/all-examples-in-one/config.xml
+++ b/UnusedLocalVariable/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UpperEll/Example1/config.xml
+++ b/UpperEll/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/UpperEll/all-examples-in-one/config.xml
+++ b/UpperEll/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VariableDeclarationUsageDistance/Example1/config.xml
+++ b/VariableDeclarationUsageDistance/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VariableDeclarationUsageDistance/Example2/config.xml
+++ b/VariableDeclarationUsageDistance/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VariableDeclarationUsageDistance/Example3/config.xml
+++ b/VariableDeclarationUsageDistance/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VariableDeclarationUsageDistance/Example4/config.xml
+++ b/VariableDeclarationUsageDistance/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VariableDeclarationUsageDistance/Example5/config.xml
+++ b/VariableDeclarationUsageDistance/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VariableDeclarationUsageDistance/Example6/config.xml
+++ b/VariableDeclarationUsageDistance/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VariableDeclarationUsageDistance/all-examples-in-one/config.xml
+++ b/VariableDeclarationUsageDistance/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example1/config.xml
+++ b/VisibilityModifier/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example10/config.xml
+++ b/VisibilityModifier/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example11/config.xml
+++ b/VisibilityModifier/Example11/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example12/config.xml
+++ b/VisibilityModifier/Example12/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example2/config.xml
+++ b/VisibilityModifier/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example3/config.xml
+++ b/VisibilityModifier/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example4/config.xml
+++ b/VisibilityModifier/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example5/config.xml
+++ b/VisibilityModifier/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example6/config.xml
+++ b/VisibilityModifier/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example7/config.xml
+++ b/VisibilityModifier/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example8/config.xml
+++ b/VisibilityModifier/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/Example9/config.xml
+++ b/VisibilityModifier/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/VisibilityModifier/all-examples-in-one/config.xml
+++ b/VisibilityModifier/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhenShouldBeUsed/Example1/config.xml
+++ b/WhenShouldBeUsed/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhenShouldBeUsed/all-examples-in-one/config.xml
+++ b/WhenShouldBeUsed/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAfter/Example1/config.xml
+++ b/WhitespaceAfter/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAfter/Example2/config.xml
+++ b/WhitespaceAfter/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAfter/all-examples-in-one/config.xml
+++ b/WhitespaceAfter/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example1/config.xml
+++ b/WhitespaceAround/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example10/config.xml
+++ b/WhitespaceAround/Example10/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example2/config.xml
+++ b/WhitespaceAround/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example3/config.xml
+++ b/WhitespaceAround/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example4/config.xml
+++ b/WhitespaceAround/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example5/config.xml
+++ b/WhitespaceAround/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example6/config.xml
+++ b/WhitespaceAround/Example6/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example7/config.xml
+++ b/WhitespaceAround/Example7/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example8/config.xml
+++ b/WhitespaceAround/Example8/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/Example9/config.xml
+++ b/WhitespaceAround/Example9/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WhitespaceAround/all-examples-in-one/config.xml
+++ b/WhitespaceAround/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WriteTag/Example1/config.xml
+++ b/WriteTag/Example1/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WriteTag/Example2/config.xml
+++ b/WriteTag/Example2/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WriteTag/Example3/config.xml
+++ b/WriteTag/Example3/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WriteTag/Example4/config.xml
+++ b/WriteTag/Example4/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WriteTag/Example5/config.xml
+++ b/WriteTag/Example5/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/WriteTag/all-examples-in-one/config.xml
+++ b/WriteTag/all-examples-in-one/config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/diff-java-tool/checkstyle-tester/checkstyle.xml
+++ b/diff-java-tool/checkstyle-tester/checkstyle.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/diff-java-tool/src/test/resources/checkstyle.xml
+++ b/diff-java-tool/src/test/resources/checkstyle.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/main/resources/config-template-treewalker.xml
+++ b/extractor/src/main/resources/config-template-treewalker.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-all-in-one.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-all-in-one.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example1.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example1.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example2.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example2.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example3.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example3.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example4.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example4.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example5.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example5.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example6.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example6.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example7.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInName/Configs/expected-config-example7.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 

--- a/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/Config/expected-config.xml
+++ b/extractor/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/Config/expected-config.xml
@@ -18,7 +18,10 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
+        <!-- We intentionally ignore all Java parse errors in regression reports.
+             Projects often use syntax newer than Checkstyle supports, so parse
+             failures must not appear as diffs or violations. Stacktrace format
+             changes would also create noisy diffs, so we suppress them entirely. -->
         <property name="skipFileOnJavaParseException" value="true"/>
         <property name="javaParseExceptionSeverity" value="ignore"/>
 


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/18079#issuecomment-3538523873

> The problem comes from the `javaParseExceptionSeverity` setting:
> - On my local run, it's set to `warning`.
> - On CI run, it's set to `ignore`.

Replaced all occurrences of
```xml
        <!-- as we run on regression even on non-compiled files we need to skip exceptions on them -->
        <property name="skipFileOnJavaParseException" value="true"/>
        <property name="javaParseExceptionSeverity" value="ignore"/>
```
with
```xml
        <!-- Regression includes non-parseable files, so we report parse errors to show when parsing changes -->
        <property name="skipFileOnJavaParseException" value="true"/>
        <property name="javaParseExceptionSeverity" value="info"/>
```

I used `info` so we can easily differentiate errors from checks and errors from parsing in diff reports. Checks use the `warning` severity.