### PR TITLE
Refactor logging to use parameterized messages

### DIFF
--- a/diff-java-tool/src/main/java/com/github/checkstyle/difftool/DiffTool.java
+++ b/diff-java-tool/src/main/java/com/github/checkstyle/difftool/DiffTool.java
@@ -199,7 +199,7 @@ public final class DiffTool {
             System.exit(1);
         }
         catch (IllegalArgumentException | IllegalStateException ex) {
-            LOGGER.error("Error in application state or arguments: " + ex.getMessage(), ex);
+            LOGGER.error("Error in application state or arguments", ex);
             System.exit(1);
         }
     }
@@ -271,7 +271,7 @@ public final class DiffTool {
             final String[] fields = trimmedLine.split(FIELD_DELIMITER);
 
             if (fields.length < MIN_FIELD_COUNT) {
-                LOGGER.warn("Skipping invalid line in projects.properties: " + trimmedLine);
+                LOGGER.warn("Skipping invalid line in projects.properties: {}", trimmedLine);
                 continue;
             }
 


### PR DESCRIPTION
This PR refactors logging statements to use parameterized SLF4J-style messages,
removing string concatenation and redundant exception message logging.

- Updated LOGGER.warn to use {} placeholders
- Simplified LOGGER.error to log exception directly

Related to #218