### PR TITLE
Issue #240: fix vavr reference

### DIFF
--- a/AbbreviationAsWordInName/Example1/list-of-projects.properties
+++ b/AbbreviationAsWordInName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/Example1/list-of-projects.yml
+++ b/AbbreviationAsWordInName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbbreviationAsWordInName/Example2/list-of-projects.properties
+++ b/AbbreviationAsWordInName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/Example2/list-of-projects.yml
+++ b/AbbreviationAsWordInName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbbreviationAsWordInName/Example3/list-of-projects.properties
+++ b/AbbreviationAsWordInName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/Example3/list-of-projects.yml
+++ b/AbbreviationAsWordInName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbbreviationAsWordInName/Example4/list-of-projects.properties
+++ b/AbbreviationAsWordInName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/Example4/list-of-projects.yml
+++ b/AbbreviationAsWordInName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbbreviationAsWordInName/Example5/list-of-projects.properties
+++ b/AbbreviationAsWordInName/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/Example5/list-of-projects.yml
+++ b/AbbreviationAsWordInName/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbbreviationAsWordInName/Example6/list-of-projects.properties
+++ b/AbbreviationAsWordInName/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/Example6/list-of-projects.yml
+++ b/AbbreviationAsWordInName/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbbreviationAsWordInName/Example7/list-of-projects.properties
+++ b/AbbreviationAsWordInName/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/Example7/list-of-projects.yml
+++ b/AbbreviationAsWordInName/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbbreviationAsWordInName/all-examples-in-one/list-of-projects.properties
+++ b/AbbreviationAsWordInName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbbreviationAsWordInName/all-examples-in-one/list-of-projects.yml
+++ b/AbbreviationAsWordInName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbstractClassName/Example1/list-of-projects.properties
+++ b/AbstractClassName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbstractClassName/Example1/list-of-projects.yml
+++ b/AbstractClassName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbstractClassName/Example2/list-of-projects.properties
+++ b/AbstractClassName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbstractClassName/Example2/list-of-projects.yml
+++ b/AbstractClassName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbstractClassName/Example3/list-of-projects.properties
+++ b/AbstractClassName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbstractClassName/Example3/list-of-projects.yml
+++ b/AbstractClassName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbstractClassName/Example4/list-of-projects.properties
+++ b/AbstractClassName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbstractClassName/Example4/list-of-projects.yml
+++ b/AbstractClassName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AbstractClassName/all-examples-in-one/list-of-projects.properties
+++ b/AbstractClassName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AbstractClassName/all-examples-in-one/list-of-projects.yml
+++ b/AbstractClassName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationLocation/Example1/list-of-projects.properties
+++ b/AnnotationLocation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationLocation/Example1/list-of-projects.yml
+++ b/AnnotationLocation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationLocation/Example2/list-of-projects.properties
+++ b/AnnotationLocation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationLocation/Example2/list-of-projects.yml
+++ b/AnnotationLocation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationLocation/Example3/list-of-projects.properties
+++ b/AnnotationLocation/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationLocation/Example3/list-of-projects.yml
+++ b/AnnotationLocation/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationLocation/Example4/list-of-projects.properties
+++ b/AnnotationLocation/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationLocation/Example4/list-of-projects.yml
+++ b/AnnotationLocation/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationLocation/all-examples-in-one/list-of-projects.properties
+++ b/AnnotationLocation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationLocation/all-examples-in-one/list-of-projects.yml
+++ b/AnnotationLocation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationOnSameLine/Example1/list-of-projects.properties
+++ b/AnnotationOnSameLine/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationOnSameLine/Example1/list-of-projects.yml
+++ b/AnnotationOnSameLine/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationOnSameLine/Example2/list-of-projects.properties
+++ b/AnnotationOnSameLine/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationOnSameLine/Example2/list-of-projects.yml
+++ b/AnnotationOnSameLine/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationOnSameLine/all-examples-in-one/list-of-projects.properties
+++ b/AnnotationOnSameLine/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationOnSameLine/all-examples-in-one/list-of-projects.yml
+++ b/AnnotationOnSameLine/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationUseStyle/Example1/list-of-projects.properties
+++ b/AnnotationUseStyle/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationUseStyle/Example1/list-of-projects.yml
+++ b/AnnotationUseStyle/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationUseStyle/Example2/list-of-projects.properties
+++ b/AnnotationUseStyle/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationUseStyle/Example2/list-of-projects.yml
+++ b/AnnotationUseStyle/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationUseStyle/Example3/list-of-projects.properties
+++ b/AnnotationUseStyle/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationUseStyle/Example3/list-of-projects.yml
+++ b/AnnotationUseStyle/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationUseStyle/Example4/list-of-projects.properties
+++ b/AnnotationUseStyle/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationUseStyle/Example4/list-of-projects.yml
+++ b/AnnotationUseStyle/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnnotationUseStyle/all-examples-in-one/list-of-projects.properties
+++ b/AnnotationUseStyle/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnnotationUseStyle/all-examples-in-one/list-of-projects.yml
+++ b/AnnotationUseStyle/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnonInnerLength/Example1/list-of-projects.properties
+++ b/AnonInnerLength/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnonInnerLength/Example1/list-of-projects.yml
+++ b/AnonInnerLength/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnonInnerLength/Example2/list-of-projects.properties
+++ b/AnonInnerLength/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnonInnerLength/Example2/list-of-projects.yml
+++ b/AnonInnerLength/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AnonInnerLength/all-examples-in-one/list-of-projects.properties
+++ b/AnonInnerLength/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AnonInnerLength/all-examples-in-one/list-of-projects.yml
+++ b/AnonInnerLength/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ArrayTrailingComma/Example1/list-of-projects.properties
+++ b/ArrayTrailingComma/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ArrayTrailingComma/Example1/list-of-projects.yml
+++ b/ArrayTrailingComma/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ArrayTrailingComma/Example2/list-of-projects.properties
+++ b/ArrayTrailingComma/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ArrayTrailingComma/Example2/list-of-projects.yml
+++ b/ArrayTrailingComma/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ArrayTrailingComma/all-examples-in-one/list-of-projects.properties
+++ b/ArrayTrailingComma/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ArrayTrailingComma/all-examples-in-one/list-of-projects.yml
+++ b/ArrayTrailingComma/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ArrayTypeStyle/Example1/list-of-projects.properties
+++ b/ArrayTypeStyle/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ArrayTypeStyle/Example1/list-of-projects.yml
+++ b/ArrayTypeStyle/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ArrayTypeStyle/Example2/list-of-projects.properties
+++ b/ArrayTypeStyle/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ArrayTypeStyle/Example2/list-of-projects.yml
+++ b/ArrayTypeStyle/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ArrayTypeStyle/all-examples-in-one/list-of-projects.properties
+++ b/ArrayTypeStyle/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ArrayTypeStyle/all-examples-in-one/list-of-projects.yml
+++ b/ArrayTypeStyle/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AtclauseOrder/Example1/list-of-projects.properties
+++ b/AtclauseOrder/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AtclauseOrder/Example1/list-of-projects.yml
+++ b/AtclauseOrder/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AtclauseOrder/Example2/list-of-projects.properties
+++ b/AtclauseOrder/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AtclauseOrder/Example2/list-of-projects.yml
+++ b/AtclauseOrder/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AtclauseOrder/Example3/list-of-projects.properties
+++ b/AtclauseOrder/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AtclauseOrder/Example3/list-of-projects.yml
+++ b/AtclauseOrder/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AtclauseOrder/all-examples-in-one/list-of-projects.properties
+++ b/AtclauseOrder/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AtclauseOrder/all-examples-in-one/list-of-projects.yml
+++ b/AtclauseOrder/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidDoubleBraceInitialization/Example1/list-of-projects.properties
+++ b/AvoidDoubleBraceInitialization/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidDoubleBraceInitialization/Example1/list-of-projects.yml
+++ b/AvoidDoubleBraceInitialization/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidDoubleBraceInitialization/all-examples-in-one/list-of-projects.properties
+++ b/AvoidDoubleBraceInitialization/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidDoubleBraceInitialization/all-examples-in-one/list-of-projects.yml
+++ b/AvoidDoubleBraceInitialization/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidEscapedUnicodeCharacters/Example1/list-of-projects.properties
+++ b/AvoidEscapedUnicodeCharacters/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidEscapedUnicodeCharacters/Example1/list-of-projects.yml
+++ b/AvoidEscapedUnicodeCharacters/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidEscapedUnicodeCharacters/Example2/list-of-projects.properties
+++ b/AvoidEscapedUnicodeCharacters/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidEscapedUnicodeCharacters/Example2/list-of-projects.yml
+++ b/AvoidEscapedUnicodeCharacters/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidEscapedUnicodeCharacters/Example3/list-of-projects.properties
+++ b/AvoidEscapedUnicodeCharacters/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidEscapedUnicodeCharacters/Example3/list-of-projects.yml
+++ b/AvoidEscapedUnicodeCharacters/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidEscapedUnicodeCharacters/Example4/list-of-projects.properties
+++ b/AvoidEscapedUnicodeCharacters/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidEscapedUnicodeCharacters/Example4/list-of-projects.yml
+++ b/AvoidEscapedUnicodeCharacters/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidEscapedUnicodeCharacters/Example5/list-of-projects.properties
+++ b/AvoidEscapedUnicodeCharacters/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidEscapedUnicodeCharacters/Example5/list-of-projects.yml
+++ b/AvoidEscapedUnicodeCharacters/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidEscapedUnicodeCharacters/all-examples-in-one/list-of-projects.properties
+++ b/AvoidEscapedUnicodeCharacters/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidEscapedUnicodeCharacters/all-examples-in-one/list-of-projects.yml
+++ b/AvoidEscapedUnicodeCharacters/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidInlineConditionals/Example1/list-of-projects.properties
+++ b/AvoidInlineConditionals/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidInlineConditionals/Example1/list-of-projects.yml
+++ b/AvoidInlineConditionals/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidInlineConditionals/all-examples-in-one/list-of-projects.properties
+++ b/AvoidInlineConditionals/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidInlineConditionals/all-examples-in-one/list-of-projects.yml
+++ b/AvoidInlineConditionals/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidNestedBlocks/Example1/list-of-projects.properties
+++ b/AvoidNestedBlocks/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidNestedBlocks/Example1/list-of-projects.yml
+++ b/AvoidNestedBlocks/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidNestedBlocks/Example2/list-of-projects.properties
+++ b/AvoidNestedBlocks/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidNestedBlocks/Example2/list-of-projects.yml
+++ b/AvoidNestedBlocks/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidNestedBlocks/all-examples-in-one/list-of-projects.properties
+++ b/AvoidNestedBlocks/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidNestedBlocks/all-examples-in-one/list-of-projects.yml
+++ b/AvoidNestedBlocks/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidNoArgumentSuperConstructorCall/Example1/list-of-projects.properties
+++ b/AvoidNoArgumentSuperConstructorCall/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidNoArgumentSuperConstructorCall/Example1/list-of-projects.yml
+++ b/AvoidNoArgumentSuperConstructorCall/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidNoArgumentSuperConstructorCall/all-examples-in-one/list-of-projects.properties
+++ b/AvoidNoArgumentSuperConstructorCall/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidNoArgumentSuperConstructorCall/all-examples-in-one/list-of-projects.yml
+++ b/AvoidNoArgumentSuperConstructorCall/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/Example1/list-of-projects.properties
+++ b/AvoidStarImport/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/Example1/list-of-projects.yml
+++ b/AvoidStarImport/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/Example2/list-of-projects.properties
+++ b/AvoidStarImport/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/Example2/list-of-projects.yml
+++ b/AvoidStarImport/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/Example3/list-of-projects.properties
+++ b/AvoidStarImport/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/Example3/list-of-projects.yml
+++ b/AvoidStarImport/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/Example4/list-of-projects.properties
+++ b/AvoidStarImport/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/Example4/list-of-projects.yml
+++ b/AvoidStarImport/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/Example5/list-of-projects.properties
+++ b/AvoidStarImport/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/Example5/list-of-projects.yml
+++ b/AvoidStarImport/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/Example6/list-of-projects.properties
+++ b/AvoidStarImport/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/Example6/list-of-projects.yml
+++ b/AvoidStarImport/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/Example7/list-of-projects.properties
+++ b/AvoidStarImport/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/Example7/list-of-projects.yml
+++ b/AvoidStarImport/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStarImport/all-examples-in-one/list-of-projects.properties
+++ b/AvoidStarImport/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStarImport/all-examples-in-one/list-of-projects.yml
+++ b/AvoidStarImport/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStaticImport/Example1/list-of-projects.properties
+++ b/AvoidStaticImport/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStaticImport/Example1/list-of-projects.yml
+++ b/AvoidStaticImport/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStaticImport/Example2/list-of-projects.properties
+++ b/AvoidStaticImport/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStaticImport/Example2/list-of-projects.yml
+++ b/AvoidStaticImport/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/AvoidStaticImport/all-examples-in-one/list-of-projects.properties
+++ b/AvoidStaticImport/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/AvoidStaticImport/all-examples-in-one/list-of-projects.yml
+++ b/AvoidStaticImport/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/BooleanExpressionComplexity/Example1/list-of-projects.properties
+++ b/BooleanExpressionComplexity/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/BooleanExpressionComplexity/Example1/list-of-projects.yml
+++ b/BooleanExpressionComplexity/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/BooleanExpressionComplexity/Example2/list-of-projects.properties
+++ b/BooleanExpressionComplexity/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/BooleanExpressionComplexity/Example2/list-of-projects.yml
+++ b/BooleanExpressionComplexity/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/BooleanExpressionComplexity/Example3/list-of-projects.properties
+++ b/BooleanExpressionComplexity/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/BooleanExpressionComplexity/Example3/list-of-projects.yml
+++ b/BooleanExpressionComplexity/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/BooleanExpressionComplexity/all-examples-in-one/list-of-projects.properties
+++ b/BooleanExpressionComplexity/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/BooleanExpressionComplexity/all-examples-in-one/list-of-projects.yml
+++ b/BooleanExpressionComplexity/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CatchParameterName/Example1/list-of-projects.properties
+++ b/CatchParameterName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CatchParameterName/Example1/list-of-projects.yml
+++ b/CatchParameterName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CatchParameterName/Example2/list-of-projects.properties
+++ b/CatchParameterName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CatchParameterName/Example2/list-of-projects.yml
+++ b/CatchParameterName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CatchParameterName/all-examples-in-one/list-of-projects.properties
+++ b/CatchParameterName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CatchParameterName/all-examples-in-one/list-of-projects.yml
+++ b/CatchParameterName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example1/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example1/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example10/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example10/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example10/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example10/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example11/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example11/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example2/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example2/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example3/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example3/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example4/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example4/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example5/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example5/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example6/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example6/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example7/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example7/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example8/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example8/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/Example9/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/Example9/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassDataAbstractionCoupling/all-examples-in-one/list-of-projects.properties
+++ b/ClassDataAbstractionCoupling/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassDataAbstractionCoupling/all-examples-in-one/list-of-projects.yml
+++ b/ClassDataAbstractionCoupling/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassFanOutComplexity/Example1/list-of-projects.properties
+++ b/ClassFanOutComplexity/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassFanOutComplexity/Example1/list-of-projects.yml
+++ b/ClassFanOutComplexity/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassFanOutComplexity/Example2/list-of-projects.properties
+++ b/ClassFanOutComplexity/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassFanOutComplexity/Example2/list-of-projects.yml
+++ b/ClassFanOutComplexity/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassFanOutComplexity/Example3/list-of-projects.properties
+++ b/ClassFanOutComplexity/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassFanOutComplexity/Example3/list-of-projects.yml
+++ b/ClassFanOutComplexity/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassFanOutComplexity/Example4/list-of-projects.properties
+++ b/ClassFanOutComplexity/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassFanOutComplexity/Example4/list-of-projects.yml
+++ b/ClassFanOutComplexity/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassFanOutComplexity/Example5/list-of-projects.properties
+++ b/ClassFanOutComplexity/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassFanOutComplexity/Example5/list-of-projects.yml
+++ b/ClassFanOutComplexity/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassFanOutComplexity/Example6/list-of-projects.properties
+++ b/ClassFanOutComplexity/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassFanOutComplexity/Example6/list-of-projects.yml
+++ b/ClassFanOutComplexity/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassFanOutComplexity/all-examples-in-one/list-of-projects.properties
+++ b/ClassFanOutComplexity/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassFanOutComplexity/all-examples-in-one/list-of-projects.yml
+++ b/ClassFanOutComplexity/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassMemberImpliedModifier/Example1/list-of-projects.properties
+++ b/ClassMemberImpliedModifier/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassMemberImpliedModifier/Example1/list-of-projects.yml
+++ b/ClassMemberImpliedModifier/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassMemberImpliedModifier/Example2/list-of-projects.properties
+++ b/ClassMemberImpliedModifier/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassMemberImpliedModifier/Example2/list-of-projects.yml
+++ b/ClassMemberImpliedModifier/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassMemberImpliedModifier/Example3/list-of-projects.properties
+++ b/ClassMemberImpliedModifier/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassMemberImpliedModifier/Example3/list-of-projects.yml
+++ b/ClassMemberImpliedModifier/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassMemberImpliedModifier/Example4/list-of-projects.properties
+++ b/ClassMemberImpliedModifier/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassMemberImpliedModifier/Example4/list-of-projects.yml
+++ b/ClassMemberImpliedModifier/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassMemberImpliedModifier/all-examples-in-one/list-of-projects.properties
+++ b/ClassMemberImpliedModifier/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassMemberImpliedModifier/all-examples-in-one/list-of-projects.yml
+++ b/ClassMemberImpliedModifier/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassTypeParameterName/Example1/list-of-projects.properties
+++ b/ClassTypeParameterName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassTypeParameterName/Example1/list-of-projects.yml
+++ b/ClassTypeParameterName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassTypeParameterName/Example2/list-of-projects.properties
+++ b/ClassTypeParameterName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassTypeParameterName/Example2/list-of-projects.yml
+++ b/ClassTypeParameterName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassTypeParameterName/Example3/list-of-projects.properties
+++ b/ClassTypeParameterName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassTypeParameterName/Example3/list-of-projects.yml
+++ b/ClassTypeParameterName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ClassTypeParameterName/all-examples-in-one/list-of-projects.properties
+++ b/ClassTypeParameterName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ClassTypeParameterName/all-examples-in-one/list-of-projects.yml
+++ b/ClassTypeParameterName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example1/list-of-projects.properties
+++ b/CommentsIndentation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example1/list-of-projects.yml
+++ b/CommentsIndentation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example2/list-of-projects.properties
+++ b/CommentsIndentation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example2/list-of-projects.yml
+++ b/CommentsIndentation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example3/list-of-projects.properties
+++ b/CommentsIndentation/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example3/list-of-projects.yml
+++ b/CommentsIndentation/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example4/list-of-projects.properties
+++ b/CommentsIndentation/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example4/list-of-projects.yml
+++ b/CommentsIndentation/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example5/list-of-projects.properties
+++ b/CommentsIndentation/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example5/list-of-projects.yml
+++ b/CommentsIndentation/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example6/list-of-projects.properties
+++ b/CommentsIndentation/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example6/list-of-projects.yml
+++ b/CommentsIndentation/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example7/list-of-projects.properties
+++ b/CommentsIndentation/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example7/list-of-projects.yml
+++ b/CommentsIndentation/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/Example8/list-of-projects.properties
+++ b/CommentsIndentation/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/Example8/list-of-projects.yml
+++ b/CommentsIndentation/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CommentsIndentation/all-examples-in-one/list-of-projects.properties
+++ b/CommentsIndentation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CommentsIndentation/all-examples-in-one/list-of-projects.yml
+++ b/CommentsIndentation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstantName/Example1/list-of-projects.properties
+++ b/ConstantName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstantName/Example1/list-of-projects.yml
+++ b/ConstantName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstantName/Example2/list-of-projects.properties
+++ b/ConstantName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstantName/Example2/list-of-projects.yml
+++ b/ConstantName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstantName/Example3/list-of-projects.properties
+++ b/ConstantName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstantName/Example3/list-of-projects.yml
+++ b/ConstantName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstantName/Example4/list-of-projects.properties
+++ b/ConstantName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstantName/Example4/list-of-projects.yml
+++ b/ConstantName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstantName/Example5/list-of-projects.properties
+++ b/ConstantName/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstantName/Example5/list-of-projects.yml
+++ b/ConstantName/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstantName/all-examples-in-one/list-of-projects.properties
+++ b/ConstantName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstantName/all-examples-in-one/list-of-projects.yml
+++ b/ConstantName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstructorsDeclarationGrouping/Example1/list-of-projects.properties
+++ b/ConstructorsDeclarationGrouping/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstructorsDeclarationGrouping/Example1/list-of-projects.yml
+++ b/ConstructorsDeclarationGrouping/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstructorsDeclarationGrouping/Example2/list-of-projects.properties
+++ b/ConstructorsDeclarationGrouping/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstructorsDeclarationGrouping/Example2/list-of-projects.yml
+++ b/ConstructorsDeclarationGrouping/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ConstructorsDeclarationGrouping/all-examples-in-one/list-of-projects.properties
+++ b/ConstructorsDeclarationGrouping/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ConstructorsDeclarationGrouping/all-examples-in-one/list-of-projects.yml
+++ b/ConstructorsDeclarationGrouping/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CovariantEquals/Example1/list-of-projects.properties
+++ b/CovariantEquals/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CovariantEquals/Example1/list-of-projects.yml
+++ b/CovariantEquals/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CovariantEquals/Example2/list-of-projects.properties
+++ b/CovariantEquals/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CovariantEquals/Example2/list-of-projects.yml
+++ b/CovariantEquals/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CovariantEquals/all-examples-in-one/list-of-projects.properties
+++ b/CovariantEquals/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CovariantEquals/all-examples-in-one/list-of-projects.yml
+++ b/CovariantEquals/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example1/list-of-projects.properties
+++ b/CustomImportOrder/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example1/list-of-projects.yml
+++ b/CustomImportOrder/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example10/list-of-projects.properties
+++ b/CustomImportOrder/Example10/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example10/list-of-projects.yml
+++ b/CustomImportOrder/Example10/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example11/list-of-projects.properties
+++ b/CustomImportOrder/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example11/list-of-projects.yml
+++ b/CustomImportOrder/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example12/list-of-projects.properties
+++ b/CustomImportOrder/Example12/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example12/list-of-projects.yml
+++ b/CustomImportOrder/Example12/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example13/list-of-projects.properties
+++ b/CustomImportOrder/Example13/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example13/list-of-projects.yml
+++ b/CustomImportOrder/Example13/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example14/list-of-projects.properties
+++ b/CustomImportOrder/Example14/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example14/list-of-projects.yml
+++ b/CustomImportOrder/Example14/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example15/list-of-projects.properties
+++ b/CustomImportOrder/Example15/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example15/list-of-projects.yml
+++ b/CustomImportOrder/Example15/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example2/list-of-projects.properties
+++ b/CustomImportOrder/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example2/list-of-projects.yml
+++ b/CustomImportOrder/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example3/list-of-projects.properties
+++ b/CustomImportOrder/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example3/list-of-projects.yml
+++ b/CustomImportOrder/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example4/list-of-projects.properties
+++ b/CustomImportOrder/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example4/list-of-projects.yml
+++ b/CustomImportOrder/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example5/list-of-projects.properties
+++ b/CustomImportOrder/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example5/list-of-projects.yml
+++ b/CustomImportOrder/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example6/list-of-projects.properties
+++ b/CustomImportOrder/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example6/list-of-projects.yml
+++ b/CustomImportOrder/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example7/list-of-projects.properties
+++ b/CustomImportOrder/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example7/list-of-projects.yml
+++ b/CustomImportOrder/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example8/list-of-projects.properties
+++ b/CustomImportOrder/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example8/list-of-projects.yml
+++ b/CustomImportOrder/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/Example9/list-of-projects.properties
+++ b/CustomImportOrder/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/Example9/list-of-projects.yml
+++ b/CustomImportOrder/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CustomImportOrder/all-examples-in-one/list-of-projects.properties
+++ b/CustomImportOrder/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CustomImportOrder/all-examples-in-one/list-of-projects.yml
+++ b/CustomImportOrder/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CyclomaticComplexity/Example1/list-of-projects.properties
+++ b/CyclomaticComplexity/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CyclomaticComplexity/Example1/list-of-projects.yml
+++ b/CyclomaticComplexity/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CyclomaticComplexity/Example2/list-of-projects.properties
+++ b/CyclomaticComplexity/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CyclomaticComplexity/Example2/list-of-projects.yml
+++ b/CyclomaticComplexity/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CyclomaticComplexity/Example3/list-of-projects.properties
+++ b/CyclomaticComplexity/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CyclomaticComplexity/Example3/list-of-projects.yml
+++ b/CyclomaticComplexity/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/CyclomaticComplexity/all-examples-in-one/list-of-projects.properties
+++ b/CyclomaticComplexity/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/CyclomaticComplexity/all-examples-in-one/list-of-projects.yml
+++ b/CyclomaticComplexity/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DeclarationOrder/Example1/list-of-projects.properties
+++ b/DeclarationOrder/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DeclarationOrder/Example1/list-of-projects.yml
+++ b/DeclarationOrder/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DeclarationOrder/Example2/list-of-projects.properties
+++ b/DeclarationOrder/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DeclarationOrder/Example2/list-of-projects.yml
+++ b/DeclarationOrder/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DeclarationOrder/Example3/list-of-projects.properties
+++ b/DeclarationOrder/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DeclarationOrder/Example3/list-of-projects.yml
+++ b/DeclarationOrder/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DeclarationOrder/all-examples-in-one/list-of-projects.properties
+++ b/DeclarationOrder/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DeclarationOrder/all-examples-in-one/list-of-projects.yml
+++ b/DeclarationOrder/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DefaultComesLast/Example1/list-of-projects.properties
+++ b/DefaultComesLast/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DefaultComesLast/Example1/list-of-projects.yml
+++ b/DefaultComesLast/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DefaultComesLast/Example2/list-of-projects.properties
+++ b/DefaultComesLast/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DefaultComesLast/Example2/list-of-projects.yml
+++ b/DefaultComesLast/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DefaultComesLast/all-examples-in-one/list-of-projects.properties
+++ b/DefaultComesLast/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DefaultComesLast/all-examples-in-one/list-of-projects.yml
+++ b/DefaultComesLast/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example1/list-of-projects.properties
+++ b/DescendantToken/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example1/list-of-projects.yml
+++ b/DescendantToken/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example10/list-of-projects.properties
+++ b/DescendantToken/Example10/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example10/list-of-projects.yml
+++ b/DescendantToken/Example10/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example11/list-of-projects.properties
+++ b/DescendantToken/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example11/list-of-projects.yml
+++ b/DescendantToken/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example12/list-of-projects.properties
+++ b/DescendantToken/Example12/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example12/list-of-projects.yml
+++ b/DescendantToken/Example12/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example13/list-of-projects.properties
+++ b/DescendantToken/Example13/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example13/list-of-projects.yml
+++ b/DescendantToken/Example13/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example14/list-of-projects.properties
+++ b/DescendantToken/Example14/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example14/list-of-projects.yml
+++ b/DescendantToken/Example14/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example15/list-of-projects.properties
+++ b/DescendantToken/Example15/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example15/list-of-projects.yml
+++ b/DescendantToken/Example15/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example16/list-of-projects.properties
+++ b/DescendantToken/Example16/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example16/list-of-projects.yml
+++ b/DescendantToken/Example16/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example17/list-of-projects.properties
+++ b/DescendantToken/Example17/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example17/list-of-projects.yml
+++ b/DescendantToken/Example17/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example2/list-of-projects.properties
+++ b/DescendantToken/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example2/list-of-projects.yml
+++ b/DescendantToken/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example3/list-of-projects.properties
+++ b/DescendantToken/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example3/list-of-projects.yml
+++ b/DescendantToken/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example4/list-of-projects.properties
+++ b/DescendantToken/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example4/list-of-projects.yml
+++ b/DescendantToken/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example5/list-of-projects.properties
+++ b/DescendantToken/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example5/list-of-projects.yml
+++ b/DescendantToken/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example6/list-of-projects.properties
+++ b/DescendantToken/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example6/list-of-projects.yml
+++ b/DescendantToken/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example7/list-of-projects.properties
+++ b/DescendantToken/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example7/list-of-projects.yml
+++ b/DescendantToken/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example8/list-of-projects.properties
+++ b/DescendantToken/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example8/list-of-projects.yml
+++ b/DescendantToken/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/Example9/list-of-projects.properties
+++ b/DescendantToken/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/Example9/list-of-projects.yml
+++ b/DescendantToken/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DescendantToken/all-examples-in-one/list-of-projects.properties
+++ b/DescendantToken/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DescendantToken/all-examples-in-one/list-of-projects.yml
+++ b/DescendantToken/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DesignForExtension/Example1/list-of-projects.properties
+++ b/DesignForExtension/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DesignForExtension/Example1/list-of-projects.yml
+++ b/DesignForExtension/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DesignForExtension/Example2/list-of-projects.properties
+++ b/DesignForExtension/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DesignForExtension/Example2/list-of-projects.yml
+++ b/DesignForExtension/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DesignForExtension/Example3/list-of-projects.properties
+++ b/DesignForExtension/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DesignForExtension/Example3/list-of-projects.yml
+++ b/DesignForExtension/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DesignForExtension/Example4/list-of-projects.properties
+++ b/DesignForExtension/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DesignForExtension/Example4/list-of-projects.yml
+++ b/DesignForExtension/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/DesignForExtension/all-examples-in-one/list-of-projects.properties
+++ b/DesignForExtension/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/DesignForExtension/all-examples-in-one/list-of-projects.yml
+++ b/DesignForExtension/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyBlock/Example1/list-of-projects.properties
+++ b/EmptyBlock/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyBlock/Example1/list-of-projects.yml
+++ b/EmptyBlock/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyBlock/Example2/list-of-projects.properties
+++ b/EmptyBlock/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyBlock/Example2/list-of-projects.yml
+++ b/EmptyBlock/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyBlock/Example3/list-of-projects.properties
+++ b/EmptyBlock/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyBlock/Example3/list-of-projects.yml
+++ b/EmptyBlock/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyBlock/all-examples-in-one/list-of-projects.properties
+++ b/EmptyBlock/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyBlock/all-examples-in-one/list-of-projects.yml
+++ b/EmptyBlock/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyCatchBlock/Example1/list-of-projects.properties
+++ b/EmptyCatchBlock/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyCatchBlock/Example1/list-of-projects.yml
+++ b/EmptyCatchBlock/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyCatchBlock/Example2/list-of-projects.properties
+++ b/EmptyCatchBlock/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyCatchBlock/Example2/list-of-projects.yml
+++ b/EmptyCatchBlock/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyCatchBlock/Example3/list-of-projects.properties
+++ b/EmptyCatchBlock/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyCatchBlock/Example3/list-of-projects.yml
+++ b/EmptyCatchBlock/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyCatchBlock/Example4/list-of-projects.properties
+++ b/EmptyCatchBlock/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyCatchBlock/Example4/list-of-projects.yml
+++ b/EmptyCatchBlock/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyCatchBlock/Example5/list-of-projects.properties
+++ b/EmptyCatchBlock/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyCatchBlock/Example5/list-of-projects.yml
+++ b/EmptyCatchBlock/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyCatchBlock/all-examples-in-one/list-of-projects.properties
+++ b/EmptyCatchBlock/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyCatchBlock/all-examples-in-one/list-of-projects.yml
+++ b/EmptyCatchBlock/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyForInitializerPad/Example1/list-of-projects.properties
+++ b/EmptyForInitializerPad/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyForInitializerPad/Example1/list-of-projects.yml
+++ b/EmptyForInitializerPad/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyForInitializerPad/Example2/list-of-projects.properties
+++ b/EmptyForInitializerPad/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyForInitializerPad/Example2/list-of-projects.yml
+++ b/EmptyForInitializerPad/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyForInitializerPad/all-examples-in-one/list-of-projects.properties
+++ b/EmptyForInitializerPad/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyForInitializerPad/all-examples-in-one/list-of-projects.yml
+++ b/EmptyForInitializerPad/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyForIteratorPad/Example1/list-of-projects.properties
+++ b/EmptyForIteratorPad/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyForIteratorPad/Example1/list-of-projects.yml
+++ b/EmptyForIteratorPad/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyForIteratorPad/Example2/list-of-projects.properties
+++ b/EmptyForIteratorPad/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyForIteratorPad/Example2/list-of-projects.yml
+++ b/EmptyForIteratorPad/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyForIteratorPad/all-examples-in-one/list-of-projects.properties
+++ b/EmptyForIteratorPad/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyForIteratorPad/all-examples-in-one/list-of-projects.yml
+++ b/EmptyForIteratorPad/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/Example1/list-of-projects.properties
+++ b/EmptyLineSeparator/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/Example1/list-of-projects.yml
+++ b/EmptyLineSeparator/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/Example2/list-of-projects.properties
+++ b/EmptyLineSeparator/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/Example2/list-of-projects.yml
+++ b/EmptyLineSeparator/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/Example3/list-of-projects.properties
+++ b/EmptyLineSeparator/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/Example3/list-of-projects.yml
+++ b/EmptyLineSeparator/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/Example4/list-of-projects.properties
+++ b/EmptyLineSeparator/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/Example4/list-of-projects.yml
+++ b/EmptyLineSeparator/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/Example5/list-of-projects.properties
+++ b/EmptyLineSeparator/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/Example5/list-of-projects.yml
+++ b/EmptyLineSeparator/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/Example6/list-of-projects.properties
+++ b/EmptyLineSeparator/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/Example6/list-of-projects.yml
+++ b/EmptyLineSeparator/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/Example7/list-of-projects.properties
+++ b/EmptyLineSeparator/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/Example7/list-of-projects.yml
+++ b/EmptyLineSeparator/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyLineSeparator/all-examples-in-one/list-of-projects.properties
+++ b/EmptyLineSeparator/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyLineSeparator/all-examples-in-one/list-of-projects.yml
+++ b/EmptyLineSeparator/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyStatement/Example1/list-of-projects.properties
+++ b/EmptyStatement/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyStatement/Example1/list-of-projects.yml
+++ b/EmptyStatement/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EmptyStatement/all-examples-in-one/list-of-projects.properties
+++ b/EmptyStatement/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EmptyStatement/all-examples-in-one/list-of-projects.yml
+++ b/EmptyStatement/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EqualsAvoidNull/Example1/list-of-projects.properties
+++ b/EqualsAvoidNull/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EqualsAvoidNull/Example1/list-of-projects.yml
+++ b/EqualsAvoidNull/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EqualsAvoidNull/Example2/list-of-projects.properties
+++ b/EqualsAvoidNull/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EqualsAvoidNull/Example2/list-of-projects.yml
+++ b/EqualsAvoidNull/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EqualsAvoidNull/all-examples-in-one/list-of-projects.properties
+++ b/EqualsAvoidNull/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EqualsAvoidNull/all-examples-in-one/list-of-projects.yml
+++ b/EqualsAvoidNull/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EqualsHashCode/Example1/list-of-projects.properties
+++ b/EqualsHashCode/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EqualsHashCode/Example1/list-of-projects.yml
+++ b/EqualsHashCode/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/EqualsHashCode/all-examples-in-one/list-of-projects.properties
+++ b/EqualsHashCode/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/EqualsHashCode/all-examples-in-one/list-of-projects.yml
+++ b/EqualsHashCode/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ExecutableStatementCount/Example1/list-of-projects.properties
+++ b/ExecutableStatementCount/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ExecutableStatementCount/Example1/list-of-projects.yml
+++ b/ExecutableStatementCount/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ExecutableStatementCount/Example2/list-of-projects.properties
+++ b/ExecutableStatementCount/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ExecutableStatementCount/Example2/list-of-projects.yml
+++ b/ExecutableStatementCount/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ExecutableStatementCount/Example3/list-of-projects.properties
+++ b/ExecutableStatementCount/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ExecutableStatementCount/Example3/list-of-projects.yml
+++ b/ExecutableStatementCount/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ExecutableStatementCount/all-examples-in-one/list-of-projects.properties
+++ b/ExecutableStatementCount/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ExecutableStatementCount/all-examples-in-one/list-of-projects.yml
+++ b/ExecutableStatementCount/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ExplicitInitialization/Example1/list-of-projects.properties
+++ b/ExplicitInitialization/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ExplicitInitialization/Example1/list-of-projects.yml
+++ b/ExplicitInitialization/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ExplicitInitialization/Example2/list-of-projects.properties
+++ b/ExplicitInitialization/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ExplicitInitialization/Example2/list-of-projects.yml
+++ b/ExplicitInitialization/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ExplicitInitialization/all-examples-in-one/list-of-projects.properties
+++ b/ExplicitInitialization/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ExplicitInitialization/all-examples-in-one/list-of-projects.yml
+++ b/ExplicitInitialization/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FallThrough/Example1/list-of-projects.properties
+++ b/FallThrough/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FallThrough/Example1/list-of-projects.yml
+++ b/FallThrough/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FallThrough/Example2/list-of-projects.properties
+++ b/FallThrough/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FallThrough/Example2/list-of-projects.yml
+++ b/FallThrough/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FallThrough/Example3/list-of-projects.properties
+++ b/FallThrough/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FallThrough/Example3/list-of-projects.yml
+++ b/FallThrough/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FallThrough/all-examples-in-one/list-of-projects.properties
+++ b/FallThrough/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FallThrough/all-examples-in-one/list-of-projects.yml
+++ b/FallThrough/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileLength/Example1/list-of-projects.properties
+++ b/FileLength/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileLength/Example1/list-of-projects.yml
+++ b/FileLength/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileLength/Example2/list-of-projects.properties
+++ b/FileLength/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileLength/Example2/list-of-projects.yml
+++ b/FileLength/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileLength/Example3/list-of-projects.properties
+++ b/FileLength/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileLength/Example3/list-of-projects.yml
+++ b/FileLength/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileLength/all-examples-in-one/list-of-projects.properties
+++ b/FileLength/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileLength/all-examples-in-one/list-of-projects.yml
+++ b/FileLength/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileTabCharacter/Example1/list-of-projects.properties
+++ b/FileTabCharacter/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileTabCharacter/Example1/list-of-projects.yml
+++ b/FileTabCharacter/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileTabCharacter/Example2/list-of-projects.properties
+++ b/FileTabCharacter/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileTabCharacter/Example2/list-of-projects.yml
+++ b/FileTabCharacter/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileTabCharacter/Example3/list-of-projects.properties
+++ b/FileTabCharacter/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileTabCharacter/Example3/list-of-projects.yml
+++ b/FileTabCharacter/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FileTabCharacter/all-examples-in-one/list-of-projects.properties
+++ b/FileTabCharacter/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FileTabCharacter/all-examples-in-one/list-of-projects.yml
+++ b/FileTabCharacter/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalClass/Example1/list-of-projects.properties
+++ b/FinalClass/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalClass/Example1/list-of-projects.yml
+++ b/FinalClass/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalClass/all-examples-in-one/list-of-projects.properties
+++ b/FinalClass/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalClass/all-examples-in-one/list-of-projects.yml
+++ b/FinalClass/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalLocalVariable/Example1/list-of-projects.properties
+++ b/FinalLocalVariable/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalLocalVariable/Example1/list-of-projects.yml
+++ b/FinalLocalVariable/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalLocalVariable/Example2/list-of-projects.properties
+++ b/FinalLocalVariable/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalLocalVariable/Example2/list-of-projects.yml
+++ b/FinalLocalVariable/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalLocalVariable/Example3/list-of-projects.properties
+++ b/FinalLocalVariable/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalLocalVariable/Example3/list-of-projects.yml
+++ b/FinalLocalVariable/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalLocalVariable/Example4/list-of-projects.properties
+++ b/FinalLocalVariable/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalLocalVariable/Example4/list-of-projects.yml
+++ b/FinalLocalVariable/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalLocalVariable/Example5/list-of-projects.properties
+++ b/FinalLocalVariable/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalLocalVariable/Example5/list-of-projects.yml
+++ b/FinalLocalVariable/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalLocalVariable/all-examples-in-one/list-of-projects.properties
+++ b/FinalLocalVariable/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalLocalVariable/all-examples-in-one/list-of-projects.yml
+++ b/FinalLocalVariable/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalParameters/Example1/list-of-projects.properties
+++ b/FinalParameters/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalParameters/Example1/list-of-projects.yml
+++ b/FinalParameters/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalParameters/Example2/list-of-projects.properties
+++ b/FinalParameters/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalParameters/Example2/list-of-projects.yml
+++ b/FinalParameters/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalParameters/Example3/list-of-projects.properties
+++ b/FinalParameters/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalParameters/Example3/list-of-projects.yml
+++ b/FinalParameters/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalParameters/Example4/list-of-projects.properties
+++ b/FinalParameters/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalParameters/Example4/list-of-projects.yml
+++ b/FinalParameters/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/FinalParameters/all-examples-in-one/list-of-projects.properties
+++ b/FinalParameters/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/FinalParameters/all-examples-in-one/list-of-projects.yml
+++ b/FinalParameters/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/GenericWhitespace/Example1/list-of-projects.properties
+++ b/GenericWhitespace/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/GenericWhitespace/Example1/list-of-projects.yml
+++ b/GenericWhitespace/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/GenericWhitespace/Example2/list-of-projects.properties
+++ b/GenericWhitespace/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/GenericWhitespace/Example2/list-of-projects.yml
+++ b/GenericWhitespace/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/GenericWhitespace/all-examples-in-one/list-of-projects.properties
+++ b/GenericWhitespace/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/GenericWhitespace/all-examples-in-one/list-of-projects.yml
+++ b/GenericWhitespace/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/GoogleNonConstantFieldName/Example1/list-of-projects.properties
+++ b/GoogleNonConstantFieldName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/GoogleNonConstantFieldName/Example1/list-of-projects.yml
+++ b/GoogleNonConstantFieldName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/GoogleNonConstantFieldName/all-examples-in-one/list-of-projects.properties
+++ b/GoogleNonConstantFieldName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/GoogleNonConstantFieldName/all-examples-in-one/list-of-projects.yml
+++ b/GoogleNonConstantFieldName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Header/Example1/list-of-projects.properties
+++ b/Header/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Header/Example1/list-of-projects.yml
+++ b/Header/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Header/Example2/list-of-projects.properties
+++ b/Header/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Header/Example2/list-of-projects.yml
+++ b/Header/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Header/Example3/list-of-projects.properties
+++ b/Header/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Header/Example3/list-of-projects.yml
+++ b/Header/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Header/Example4/list-of-projects.properties
+++ b/Header/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Header/Example4/list-of-projects.yml
+++ b/Header/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Header/all-examples-in-one/list-of-projects.properties
+++ b/Header/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Header/all-examples-in-one/list-of-projects.yml
+++ b/Header/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HexLiteralCase/Example1/list-of-projects.properties
+++ b/HexLiteralCase/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HexLiteralCase/Example1/list-of-projects.yml
+++ b/HexLiteralCase/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HexLiteralCase/all-examples-in-one/list-of-projects.properties
+++ b/HexLiteralCase/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HexLiteralCase/all-examples-in-one/list-of-projects.yml
+++ b/HexLiteralCase/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/Example1/list-of-projects.properties
+++ b/HiddenField/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/Example1/list-of-projects.yml
+++ b/HiddenField/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/Example2/list-of-projects.properties
+++ b/HiddenField/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/Example2/list-of-projects.yml
+++ b/HiddenField/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/Example3/list-of-projects.properties
+++ b/HiddenField/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/Example3/list-of-projects.yml
+++ b/HiddenField/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/Example4/list-of-projects.properties
+++ b/HiddenField/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/Example4/list-of-projects.yml
+++ b/HiddenField/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/Example5/list-of-projects.properties
+++ b/HiddenField/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/Example5/list-of-projects.yml
+++ b/HiddenField/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/Example6/list-of-projects.properties
+++ b/HiddenField/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/Example6/list-of-projects.yml
+++ b/HiddenField/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/Example7/list-of-projects.properties
+++ b/HiddenField/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/Example7/list-of-projects.yml
+++ b/HiddenField/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HiddenField/all-examples-in-one/list-of-projects.properties
+++ b/HiddenField/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HiddenField/all-examples-in-one/list-of-projects.yml
+++ b/HiddenField/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HideUtilityClassConstructor/Example1/list-of-projects.properties
+++ b/HideUtilityClassConstructor/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HideUtilityClassConstructor/Example1/list-of-projects.yml
+++ b/HideUtilityClassConstructor/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HideUtilityClassConstructor/Example2/list-of-projects.properties
+++ b/HideUtilityClassConstructor/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HideUtilityClassConstructor/Example2/list-of-projects.yml
+++ b/HideUtilityClassConstructor/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/HideUtilityClassConstructor/all-examples-in-one/list-of-projects.properties
+++ b/HideUtilityClassConstructor/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/HideUtilityClassConstructor/all-examples-in-one/list-of-projects.yml
+++ b/HideUtilityClassConstructor/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalCatch/Example1/list-of-projects.properties
+++ b/IllegalCatch/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalCatch/Example1/list-of-projects.yml
+++ b/IllegalCatch/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalCatch/Example2/list-of-projects.properties
+++ b/IllegalCatch/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalCatch/Example2/list-of-projects.yml
+++ b/IllegalCatch/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalCatch/all-examples-in-one/list-of-projects.properties
+++ b/IllegalCatch/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalCatch/all-examples-in-one/list-of-projects.yml
+++ b/IllegalCatch/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalIdentifierName/Example1/list-of-projects.properties
+++ b/IllegalIdentifierName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalIdentifierName/Example1/list-of-projects.yml
+++ b/IllegalIdentifierName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalIdentifierName/Example2/list-of-projects.properties
+++ b/IllegalIdentifierName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalIdentifierName/Example2/list-of-projects.yml
+++ b/IllegalIdentifierName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalIdentifierName/all-examples-in-one/list-of-projects.properties
+++ b/IllegalIdentifierName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalIdentifierName/all-examples-in-one/list-of-projects.yml
+++ b/IllegalIdentifierName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalImport/Example1/list-of-projects.properties
+++ b/IllegalImport/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalImport/Example1/list-of-projects.yml
+++ b/IllegalImport/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalImport/Example2/list-of-projects.properties
+++ b/IllegalImport/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalImport/Example2/list-of-projects.yml
+++ b/IllegalImport/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalImport/Example3/list-of-projects.properties
+++ b/IllegalImport/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalImport/Example3/list-of-projects.yml
+++ b/IllegalImport/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalImport/Example4/list-of-projects.properties
+++ b/IllegalImport/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalImport/Example4/list-of-projects.yml
+++ b/IllegalImport/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalImport/Example5/list-of-projects.properties
+++ b/IllegalImport/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalImport/Example5/list-of-projects.yml
+++ b/IllegalImport/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalImport/Example6/list-of-projects.properties
+++ b/IllegalImport/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalImport/Example6/list-of-projects.yml
+++ b/IllegalImport/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalImport/all-examples-in-one/list-of-projects.properties
+++ b/IllegalImport/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalImport/all-examples-in-one/list-of-projects.yml
+++ b/IllegalImport/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalInstantiation/Example1/list-of-projects.properties
+++ b/IllegalInstantiation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalInstantiation/Example1/list-of-projects.yml
+++ b/IllegalInstantiation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalInstantiation/Example2/list-of-projects.properties
+++ b/IllegalInstantiation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalInstantiation/Example2/list-of-projects.yml
+++ b/IllegalInstantiation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalInstantiation/Example3/list-of-projects.properties
+++ b/IllegalInstantiation/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalInstantiation/Example3/list-of-projects.yml
+++ b/IllegalInstantiation/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalInstantiation/all-examples-in-one/list-of-projects.properties
+++ b/IllegalInstantiation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalInstantiation/all-examples-in-one/list-of-projects.yml
+++ b/IllegalInstantiation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalSymbol/Example1/list-of-projects.properties
+++ b/IllegalSymbol/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalSymbol/Example1/list-of-projects.yml
+++ b/IllegalSymbol/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalSymbol/Example2/list-of-projects.properties
+++ b/IllegalSymbol/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalSymbol/Example2/list-of-projects.yml
+++ b/IllegalSymbol/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalSymbol/Example3/list-of-projects.properties
+++ b/IllegalSymbol/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalSymbol/Example3/list-of-projects.yml
+++ b/IllegalSymbol/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalSymbol/Example4/list-of-projects.properties
+++ b/IllegalSymbol/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalSymbol/Example4/list-of-projects.yml
+++ b/IllegalSymbol/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalSymbol/Example5/list-of-projects.properties
+++ b/IllegalSymbol/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalSymbol/Example5/list-of-projects.yml
+++ b/IllegalSymbol/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalSymbol/all-examples-in-one/list-of-projects.properties
+++ b/IllegalSymbol/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalSymbol/all-examples-in-one/list-of-projects.yml
+++ b/IllegalSymbol/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalThrows/Example1/list-of-projects.properties
+++ b/IllegalThrows/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalThrows/Example1/list-of-projects.yml
+++ b/IllegalThrows/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalThrows/Example2/list-of-projects.properties
+++ b/IllegalThrows/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalThrows/Example2/list-of-projects.yml
+++ b/IllegalThrows/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalThrows/Example3/list-of-projects.properties
+++ b/IllegalThrows/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalThrows/Example3/list-of-projects.yml
+++ b/IllegalThrows/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalThrows/Example4/list-of-projects.properties
+++ b/IllegalThrows/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalThrows/Example4/list-of-projects.yml
+++ b/IllegalThrows/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalThrows/all-examples-in-one/list-of-projects.properties
+++ b/IllegalThrows/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalThrows/all-examples-in-one/list-of-projects.yml
+++ b/IllegalThrows/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalToken/Example1/list-of-projects.properties
+++ b/IllegalToken/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalToken/Example1/list-of-projects.yml
+++ b/IllegalToken/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalToken/Example2/list-of-projects.properties
+++ b/IllegalToken/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalToken/Example2/list-of-projects.yml
+++ b/IllegalToken/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalToken/all-examples-in-one/list-of-projects.properties
+++ b/IllegalToken/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalToken/all-examples-in-one/list-of-projects.yml
+++ b/IllegalToken/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalTokenText/Example1/list-of-projects.properties
+++ b/IllegalTokenText/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalTokenText/Example1/list-of-projects.yml
+++ b/IllegalTokenText/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalTokenText/Example2/list-of-projects.properties
+++ b/IllegalTokenText/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalTokenText/Example2/list-of-projects.yml
+++ b/IllegalTokenText/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalTokenText/Example3/list-of-projects.properties
+++ b/IllegalTokenText/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalTokenText/Example3/list-of-projects.yml
+++ b/IllegalTokenText/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalTokenText/Example4/list-of-projects.properties
+++ b/IllegalTokenText/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalTokenText/Example4/list-of-projects.yml
+++ b/IllegalTokenText/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalTokenText/Example5/list-of-projects.properties
+++ b/IllegalTokenText/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalTokenText/Example5/list-of-projects.yml
+++ b/IllegalTokenText/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalTokenText/all-examples-in-one/list-of-projects.properties
+++ b/IllegalTokenText/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalTokenText/all-examples-in-one/list-of-projects.yml
+++ b/IllegalTokenText/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example1/list-of-projects.properties
+++ b/IllegalType/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example1/list-of-projects.yml
+++ b/IllegalType/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example2/list-of-projects.properties
+++ b/IllegalType/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example2/list-of-projects.yml
+++ b/IllegalType/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example3/list-of-projects.properties
+++ b/IllegalType/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example3/list-of-projects.yml
+++ b/IllegalType/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example4/list-of-projects.properties
+++ b/IllegalType/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example4/list-of-projects.yml
+++ b/IllegalType/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example5/list-of-projects.properties
+++ b/IllegalType/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example5/list-of-projects.yml
+++ b/IllegalType/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example6/list-of-projects.properties
+++ b/IllegalType/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example6/list-of-projects.yml
+++ b/IllegalType/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example7/list-of-projects.properties
+++ b/IllegalType/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example7/list-of-projects.yml
+++ b/IllegalType/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example8/list-of-projects.properties
+++ b/IllegalType/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example8/list-of-projects.yml
+++ b/IllegalType/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/Example9/list-of-projects.properties
+++ b/IllegalType/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/Example9/list-of-projects.yml
+++ b/IllegalType/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/IllegalType/all-examples-in-one/list-of-projects.properties
+++ b/IllegalType/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/IllegalType/all-examples-in-one/list-of-projects.yml
+++ b/IllegalType/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example1/list-of-projects.properties
+++ b/ImportControl/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example1/list-of-projects.yml
+++ b/ImportControl/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example10/list-of-projects.properties
+++ b/ImportControl/Example10/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example10/list-of-projects.yml
+++ b/ImportControl/Example10/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example11/list-of-projects.properties
+++ b/ImportControl/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example11/list-of-projects.yml
+++ b/ImportControl/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example12/list-of-projects.properties
+++ b/ImportControl/Example12/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example12/list-of-projects.yml
+++ b/ImportControl/Example12/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example13/list-of-projects.properties
+++ b/ImportControl/Example13/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example13/list-of-projects.yml
+++ b/ImportControl/Example13/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example14/list-of-projects.properties
+++ b/ImportControl/Example14/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example14/list-of-projects.yml
+++ b/ImportControl/Example14/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example2/list-of-projects.properties
+++ b/ImportControl/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example2/list-of-projects.yml
+++ b/ImportControl/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example4/list-of-projects.properties
+++ b/ImportControl/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example4/list-of-projects.yml
+++ b/ImportControl/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example5/list-of-projects.properties
+++ b/ImportControl/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example5/list-of-projects.yml
+++ b/ImportControl/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example6/list-of-projects.properties
+++ b/ImportControl/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example6/list-of-projects.yml
+++ b/ImportControl/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example7/list-of-projects.properties
+++ b/ImportControl/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example7/list-of-projects.yml
+++ b/ImportControl/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/Example8/list-of-projects.properties
+++ b/ImportControl/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/Example8/list-of-projects.yml
+++ b/ImportControl/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportControl/all-examples-in-one/list-of-projects.properties
+++ b/ImportControl/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportControl/all-examples-in-one/list-of-projects.yml
+++ b/ImportControl/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example1/list-of-projects.properties
+++ b/ImportOrder/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example1/list-of-projects.yml
+++ b/ImportOrder/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example10/list-of-projects.properties
+++ b/ImportOrder/Example10/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example10/list-of-projects.yml
+++ b/ImportOrder/Example10/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example11/list-of-projects.properties
+++ b/ImportOrder/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example11/list-of-projects.yml
+++ b/ImportOrder/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example12/list-of-projects.properties
+++ b/ImportOrder/Example12/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example12/list-of-projects.yml
+++ b/ImportOrder/Example12/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example2/list-of-projects.properties
+++ b/ImportOrder/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example2/list-of-projects.yml
+++ b/ImportOrder/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example3/list-of-projects.properties
+++ b/ImportOrder/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example3/list-of-projects.yml
+++ b/ImportOrder/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example4/list-of-projects.properties
+++ b/ImportOrder/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example4/list-of-projects.yml
+++ b/ImportOrder/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example5/list-of-projects.properties
+++ b/ImportOrder/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example5/list-of-projects.yml
+++ b/ImportOrder/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example6/list-of-projects.properties
+++ b/ImportOrder/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example6/list-of-projects.yml
+++ b/ImportOrder/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example7/list-of-projects.properties
+++ b/ImportOrder/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example7/list-of-projects.yml
+++ b/ImportOrder/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example8/list-of-projects.properties
+++ b/ImportOrder/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example8/list-of-projects.yml
+++ b/ImportOrder/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/Example9/list-of-projects.properties
+++ b/ImportOrder/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/Example9/list-of-projects.yml
+++ b/ImportOrder/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ImportOrder/all-examples-in-one/list-of-projects.properties
+++ b/ImportOrder/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ImportOrder/all-examples-in-one/list-of-projects.yml
+++ b/ImportOrder/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example1/list-of-projects.properties
+++ b/Indentation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example1/list-of-projects.yml
+++ b/Indentation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example2/list-of-projects.properties
+++ b/Indentation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example2/list-of-projects.yml
+++ b/Indentation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example3/list-of-projects.properties
+++ b/Indentation/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example3/list-of-projects.yml
+++ b/Indentation/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example4/list-of-projects.properties
+++ b/Indentation/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example4/list-of-projects.yml
+++ b/Indentation/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example5/list-of-projects.properties
+++ b/Indentation/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example5/list-of-projects.yml
+++ b/Indentation/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example6/list-of-projects.properties
+++ b/Indentation/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example6/list-of-projects.yml
+++ b/Indentation/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example7/list-of-projects.properties
+++ b/Indentation/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example7/list-of-projects.yml
+++ b/Indentation/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example8/list-of-projects.properties
+++ b/Indentation/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example8/list-of-projects.yml
+++ b/Indentation/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/Example9/list-of-projects.properties
+++ b/Indentation/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/Example9/list-of-projects.yml
+++ b/Indentation/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Indentation/all-examples-in-one/list-of-projects.properties
+++ b/Indentation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Indentation/all-examples-in-one/list-of-projects.yml
+++ b/Indentation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InnerAssignment/Example1/list-of-projects.properties
+++ b/InnerAssignment/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InnerAssignment/Example1/list-of-projects.yml
+++ b/InnerAssignment/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InnerAssignment/Example2/list-of-projects.properties
+++ b/InnerAssignment/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InnerAssignment/Example2/list-of-projects.yml
+++ b/InnerAssignment/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InnerAssignment/all-examples-in-one/list-of-projects.properties
+++ b/InnerAssignment/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InnerAssignment/all-examples-in-one/list-of-projects.yml
+++ b/InnerAssignment/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InnerTypeLast/Example1/list-of-projects.properties
+++ b/InnerTypeLast/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InnerTypeLast/Example1/list-of-projects.yml
+++ b/InnerTypeLast/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InnerTypeLast/all-examples-in-one/list-of-projects.properties
+++ b/InnerTypeLast/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InnerTypeLast/all-examples-in-one/list-of-projects.yml
+++ b/InnerTypeLast/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceIsType/Example1/list-of-projects.properties
+++ b/InterfaceIsType/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceIsType/Example1/list-of-projects.yml
+++ b/InterfaceIsType/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceIsType/Example2/list-of-projects.properties
+++ b/InterfaceIsType/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceIsType/Example2/list-of-projects.yml
+++ b/InterfaceIsType/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceIsType/all-examples-in-one/list-of-projects.properties
+++ b/InterfaceIsType/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceIsType/all-examples-in-one/list-of-projects.yml
+++ b/InterfaceIsType/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceMemberImpliedModifier/Example1/list-of-projects.properties
+++ b/InterfaceMemberImpliedModifier/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceMemberImpliedModifier/Example1/list-of-projects.yml
+++ b/InterfaceMemberImpliedModifier/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceMemberImpliedModifier/Example2/list-of-projects.properties
+++ b/InterfaceMemberImpliedModifier/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceMemberImpliedModifier/Example2/list-of-projects.yml
+++ b/InterfaceMemberImpliedModifier/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceMemberImpliedModifier/Example3/list-of-projects.properties
+++ b/InterfaceMemberImpliedModifier/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceMemberImpliedModifier/Example3/list-of-projects.yml
+++ b/InterfaceMemberImpliedModifier/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceMemberImpliedModifier/Example4/list-of-projects.properties
+++ b/InterfaceMemberImpliedModifier/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceMemberImpliedModifier/Example4/list-of-projects.yml
+++ b/InterfaceMemberImpliedModifier/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceMemberImpliedModifier/all-examples-in-one/list-of-projects.properties
+++ b/InterfaceMemberImpliedModifier/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceMemberImpliedModifier/all-examples-in-one/list-of-projects.yml
+++ b/InterfaceMemberImpliedModifier/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceTypeParameterName/Example1/list-of-projects.properties
+++ b/InterfaceTypeParameterName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceTypeParameterName/Example1/list-of-projects.yml
+++ b/InterfaceTypeParameterName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceTypeParameterName/Example2/list-of-projects.properties
+++ b/InterfaceTypeParameterName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceTypeParameterName/Example2/list-of-projects.yml
+++ b/InterfaceTypeParameterName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InterfaceTypeParameterName/all-examples-in-one/list-of-projects.properties
+++ b/InterfaceTypeParameterName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InterfaceTypeParameterName/all-examples-in-one/list-of-projects.yml
+++ b/InterfaceTypeParameterName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InvalidJavadocPosition/Example1/list-of-projects.properties
+++ b/InvalidJavadocPosition/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InvalidJavadocPosition/Example1/list-of-projects.yml
+++ b/InvalidJavadocPosition/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/InvalidJavadocPosition/all-examples-in-one/list-of-projects.properties
+++ b/InvalidJavadocPosition/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/InvalidJavadocPosition/all-examples-in-one/list-of-projects.yml
+++ b/InvalidJavadocPosition/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavaNCSS/Example1/list-of-projects.properties
+++ b/JavaNCSS/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavaNCSS/Example1/list-of-projects.yml
+++ b/JavaNCSS/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavaNCSS/Example2/list-of-projects.properties
+++ b/JavaNCSS/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavaNCSS/Example2/list-of-projects.yml
+++ b/JavaNCSS/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavaNCSS/Example3/list-of-projects.properties
+++ b/JavaNCSS/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavaNCSS/Example3/list-of-projects.yml
+++ b/JavaNCSS/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavaNCSS/Example4/list-of-projects.properties
+++ b/JavaNCSS/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavaNCSS/Example4/list-of-projects.yml
+++ b/JavaNCSS/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavaNCSS/Example5/list-of-projects.properties
+++ b/JavaNCSS/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavaNCSS/Example5/list-of-projects.yml
+++ b/JavaNCSS/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavaNCSS/all-examples-in-one/list-of-projects.properties
+++ b/JavaNCSS/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavaNCSS/all-examples-in-one/list-of-projects.yml
+++ b/JavaNCSS/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocBlockTagLocation/Example1/list-of-projects.properties
+++ b/JavadocBlockTagLocation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocBlockTagLocation/Example1/list-of-projects.yml
+++ b/JavadocBlockTagLocation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocBlockTagLocation/Example2/list-of-projects.properties
+++ b/JavadocBlockTagLocation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocBlockTagLocation/Example2/list-of-projects.yml
+++ b/JavadocBlockTagLocation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocBlockTagLocation/Example3/list-of-projects.properties
+++ b/JavadocBlockTagLocation/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocBlockTagLocation/Example3/list-of-projects.yml
+++ b/JavadocBlockTagLocation/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocBlockTagLocation/all-examples-in-one/list-of-projects.properties
+++ b/JavadocBlockTagLocation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocBlockTagLocation/all-examples-in-one/list-of-projects.yml
+++ b/JavadocBlockTagLocation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocContentLocation/Example1/list-of-projects.properties
+++ b/JavadocContentLocation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocContentLocation/Example1/list-of-projects.yml
+++ b/JavadocContentLocation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocContentLocation/Example2/list-of-projects.properties
+++ b/JavadocContentLocation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocContentLocation/Example2/list-of-projects.yml
+++ b/JavadocContentLocation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocContentLocation/all-examples-in-one/list-of-projects.properties
+++ b/JavadocContentLocation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocContentLocation/all-examples-in-one/list-of-projects.yml
+++ b/JavadocContentLocation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocLeadingAsteriskAlign/Example1/list-of-projects.properties
+++ b/JavadocLeadingAsteriskAlign/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocLeadingAsteriskAlign/Example1/list-of-projects.yml
+++ b/JavadocLeadingAsteriskAlign/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocLeadingAsteriskAlign/Example2/list-of-projects.properties
+++ b/JavadocLeadingAsteriskAlign/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocLeadingAsteriskAlign/Example2/list-of-projects.yml
+++ b/JavadocLeadingAsteriskAlign/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocLeadingAsteriskAlign/Example3/list-of-projects.properties
+++ b/JavadocLeadingAsteriskAlign/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocLeadingAsteriskAlign/Example3/list-of-projects.yml
+++ b/JavadocLeadingAsteriskAlign/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocLeadingAsteriskAlign/all-examples-in-one/list-of-projects.properties
+++ b/JavadocLeadingAsteriskAlign/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocLeadingAsteriskAlign/all-examples-in-one/list-of-projects.yml
+++ b/JavadocLeadingAsteriskAlign/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example1/list-of-projects.properties
+++ b/JavadocMethod/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example1/list-of-projects.yml
+++ b/JavadocMethod/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example2/list-of-projects.properties
+++ b/JavadocMethod/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example2/list-of-projects.yml
+++ b/JavadocMethod/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example3/list-of-projects.properties
+++ b/JavadocMethod/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example3/list-of-projects.yml
+++ b/JavadocMethod/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example4/list-of-projects.properties
+++ b/JavadocMethod/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example4/list-of-projects.yml
+++ b/JavadocMethod/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example5/list-of-projects.properties
+++ b/JavadocMethod/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example5/list-of-projects.yml
+++ b/JavadocMethod/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example6/list-of-projects.properties
+++ b/JavadocMethod/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example6/list-of-projects.yml
+++ b/JavadocMethod/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example7/list-of-projects.properties
+++ b/JavadocMethod/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example7/list-of-projects.yml
+++ b/JavadocMethod/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/Example8/list-of-projects.properties
+++ b/JavadocMethod/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/Example8/list-of-projects.yml
+++ b/JavadocMethod/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMethod/all-examples-in-one/list-of-projects.properties
+++ b/JavadocMethod/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMethod/all-examples-in-one/list-of-projects.yml
+++ b/JavadocMethod/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMissingLeadingAsterisk/Example1/list-of-projects.properties
+++ b/JavadocMissingLeadingAsterisk/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMissingLeadingAsterisk/Example1/list-of-projects.yml
+++ b/JavadocMissingLeadingAsterisk/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMissingLeadingAsterisk/all-examples-in-one/list-of-projects.properties
+++ b/JavadocMissingLeadingAsterisk/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMissingLeadingAsterisk/all-examples-in-one/list-of-projects.yml
+++ b/JavadocMissingLeadingAsterisk/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMissingWhitespaceAfterAsterisk/Example1/list-of-projects.properties
+++ b/JavadocMissingWhitespaceAfterAsterisk/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMissingWhitespaceAfterAsterisk/Example1/list-of-projects.yml
+++ b/JavadocMissingWhitespaceAfterAsterisk/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocMissingWhitespaceAfterAsterisk/all-examples-in-one/list-of-projects.properties
+++ b/JavadocMissingWhitespaceAfterAsterisk/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocMissingWhitespaceAfterAsterisk/all-examples-in-one/list-of-projects.yml
+++ b/JavadocMissingWhitespaceAfterAsterisk/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocPackage/Example1/list-of-projects.properties
+++ b/JavadocPackage/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocPackage/Example1/list-of-projects.yml
+++ b/JavadocPackage/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocPackage/Example2/list-of-projects.properties
+++ b/JavadocPackage/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocPackage/Example2/list-of-projects.yml
+++ b/JavadocPackage/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocPackage/Example3/list-of-projects.properties
+++ b/JavadocPackage/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocPackage/Example3/list-of-projects.yml
+++ b/JavadocPackage/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocPackage/all-examples-in-one/list-of-projects.properties
+++ b/JavadocPackage/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocPackage/all-examples-in-one/list-of-projects.yml
+++ b/JavadocPackage/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocParagraph/Example1/list-of-projects.properties
+++ b/JavadocParagraph/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocParagraph/Example1/list-of-projects.yml
+++ b/JavadocParagraph/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocParagraph/Example2/list-of-projects.properties
+++ b/JavadocParagraph/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocParagraph/Example2/list-of-projects.yml
+++ b/JavadocParagraph/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocParagraph/all-examples-in-one/list-of-projects.properties
+++ b/JavadocParagraph/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocParagraph/all-examples-in-one/list-of-projects.yml
+++ b/JavadocParagraph/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example1/list-of-projects.properties
+++ b/JavadocStyle/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example1/list-of-projects.yml
+++ b/JavadocStyle/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example2/list-of-projects.properties
+++ b/JavadocStyle/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example2/list-of-projects.yml
+++ b/JavadocStyle/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example3/list-of-projects.properties
+++ b/JavadocStyle/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example3/list-of-projects.yml
+++ b/JavadocStyle/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example4/list-of-projects.properties
+++ b/JavadocStyle/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example4/list-of-projects.yml
+++ b/JavadocStyle/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example5/list-of-projects.properties
+++ b/JavadocStyle/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example5/list-of-projects.yml
+++ b/JavadocStyle/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example6/list-of-projects.properties
+++ b/JavadocStyle/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example6/list-of-projects.yml
+++ b/JavadocStyle/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example7/list-of-projects.properties
+++ b/JavadocStyle/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example7/list-of-projects.yml
+++ b/JavadocStyle/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/Example8/list-of-projects.properties
+++ b/JavadocStyle/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/Example8/list-of-projects.yml
+++ b/JavadocStyle/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocStyle/all-examples-in-one/list-of-projects.properties
+++ b/JavadocStyle/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocStyle/all-examples-in-one/list-of-projects.yml
+++ b/JavadocStyle/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocTagContinuationIndentation/Example1/list-of-projects.properties
+++ b/JavadocTagContinuationIndentation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocTagContinuationIndentation/Example1/list-of-projects.yml
+++ b/JavadocTagContinuationIndentation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocTagContinuationIndentation/Example2/list-of-projects.properties
+++ b/JavadocTagContinuationIndentation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocTagContinuationIndentation/Example2/list-of-projects.yml
+++ b/JavadocTagContinuationIndentation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocTagContinuationIndentation/Example3/list-of-projects.properties
+++ b/JavadocTagContinuationIndentation/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocTagContinuationIndentation/Example3/list-of-projects.yml
+++ b/JavadocTagContinuationIndentation/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocTagContinuationIndentation/all-examples-in-one/list-of-projects.properties
+++ b/JavadocTagContinuationIndentation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocTagContinuationIndentation/all-examples-in-one/list-of-projects.yml
+++ b/JavadocTagContinuationIndentation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example1/list-of-projects.properties
+++ b/JavadocType/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example1/list-of-projects.yml
+++ b/JavadocType/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example2/list-of-projects.properties
+++ b/JavadocType/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example2/list-of-projects.yml
+++ b/JavadocType/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example3/list-of-projects.properties
+++ b/JavadocType/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example3/list-of-projects.yml
+++ b/JavadocType/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example4/list-of-projects.properties
+++ b/JavadocType/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example4/list-of-projects.yml
+++ b/JavadocType/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example5/list-of-projects.properties
+++ b/JavadocType/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example5/list-of-projects.yml
+++ b/JavadocType/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example6/list-of-projects.properties
+++ b/JavadocType/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example6/list-of-projects.yml
+++ b/JavadocType/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example7/list-of-projects.properties
+++ b/JavadocType/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example7/list-of-projects.yml
+++ b/JavadocType/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/Example8/list-of-projects.properties
+++ b/JavadocType/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/Example8/list-of-projects.yml
+++ b/JavadocType/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocType/all-examples-in-one/list-of-projects.properties
+++ b/JavadocType/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocType/all-examples-in-one/list-of-projects.yml
+++ b/JavadocType/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocVariable/Example1/list-of-projects.properties
+++ b/JavadocVariable/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocVariable/Example1/list-of-projects.yml
+++ b/JavadocVariable/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocVariable/Example2/list-of-projects.properties
+++ b/JavadocVariable/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocVariable/Example2/list-of-projects.yml
+++ b/JavadocVariable/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocVariable/Example3/list-of-projects.properties
+++ b/JavadocVariable/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocVariable/Example3/list-of-projects.yml
+++ b/JavadocVariable/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocVariable/Example4/list-of-projects.properties
+++ b/JavadocVariable/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocVariable/Example4/list-of-projects.yml
+++ b/JavadocVariable/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocVariable/Example5/list-of-projects.properties
+++ b/JavadocVariable/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocVariable/Example5/list-of-projects.yml
+++ b/JavadocVariable/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/JavadocVariable/all-examples-in-one/list-of-projects.properties
+++ b/JavadocVariable/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/JavadocVariable/all-examples-in-one/list-of-projects.yml
+++ b/JavadocVariable/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LambdaBodyLength/Example1/list-of-projects.properties
+++ b/LambdaBodyLength/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LambdaBodyLength/Example1/list-of-projects.yml
+++ b/LambdaBodyLength/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LambdaBodyLength/Example2/list-of-projects.properties
+++ b/LambdaBodyLength/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LambdaBodyLength/Example2/list-of-projects.yml
+++ b/LambdaBodyLength/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LambdaBodyLength/all-examples-in-one/list-of-projects.properties
+++ b/LambdaBodyLength/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LambdaBodyLength/all-examples-in-one/list-of-projects.yml
+++ b/LambdaBodyLength/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LambdaParameterName/Example1/list-of-projects.properties
+++ b/LambdaParameterName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LambdaParameterName/Example1/list-of-projects.yml
+++ b/LambdaParameterName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LambdaParameterName/Example2/list-of-projects.properties
+++ b/LambdaParameterName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LambdaParameterName/Example2/list-of-projects.yml
+++ b/LambdaParameterName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LambdaParameterName/all-examples-in-one/list-of-projects.properties
+++ b/LambdaParameterName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LambdaParameterName/all-examples-in-one/list-of-projects.yml
+++ b/LambdaParameterName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LeftCurly/Example1/list-of-projects.properties
+++ b/LeftCurly/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LeftCurly/Example1/list-of-projects.yml
+++ b/LeftCurly/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LeftCurly/Example2/list-of-projects.properties
+++ b/LeftCurly/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LeftCurly/Example2/list-of-projects.yml
+++ b/LeftCurly/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LeftCurly/Example3/list-of-projects.properties
+++ b/LeftCurly/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LeftCurly/Example3/list-of-projects.yml
+++ b/LeftCurly/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LeftCurly/Example4/list-of-projects.properties
+++ b/LeftCurly/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LeftCurly/Example4/list-of-projects.yml
+++ b/LeftCurly/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LeftCurly/all-examples-in-one/list-of-projects.properties
+++ b/LeftCurly/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LeftCurly/all-examples-in-one/list-of-projects.yml
+++ b/LeftCurly/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineEnding/Example1/list-of-projects.properties
+++ b/LineEnding/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineEnding/Example1/list-of-projects.yml
+++ b/LineEnding/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineEnding/Example2/list-of-projects.properties
+++ b/LineEnding/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineEnding/Example2/list-of-projects.yml
+++ b/LineEnding/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineEnding/Example3/list-of-projects.properties
+++ b/LineEnding/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineEnding/Example3/list-of-projects.yml
+++ b/LineEnding/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineEnding/all-examples-in-one/list-of-projects.properties
+++ b/LineEnding/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineEnding/all-examples-in-one/list-of-projects.yml
+++ b/LineEnding/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineLength/Example1/list-of-projects.properties
+++ b/LineLength/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineLength/Example1/list-of-projects.yml
+++ b/LineLength/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineLength/Example2/list-of-projects.properties
+++ b/LineLength/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineLength/Example2/list-of-projects.yml
+++ b/LineLength/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineLength/Example3/list-of-projects.properties
+++ b/LineLength/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineLength/Example3/list-of-projects.yml
+++ b/LineLength/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineLength/Example4/list-of-projects.properties
+++ b/LineLength/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineLength/Example4/list-of-projects.yml
+++ b/LineLength/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineLength/Example5/list-of-projects.properties
+++ b/LineLength/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineLength/Example5/list-of-projects.yml
+++ b/LineLength/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineLength/Example6/list-of-projects.properties
+++ b/LineLength/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineLength/Example6/list-of-projects.yml
+++ b/LineLength/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LineLength/all-examples-in-one/list-of-projects.properties
+++ b/LineLength/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LineLength/all-examples-in-one/list-of-projects.yml
+++ b/LineLength/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalFinalVariableName/Example1/list-of-projects.properties
+++ b/LocalFinalVariableName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalFinalVariableName/Example1/list-of-projects.yml
+++ b/LocalFinalVariableName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalFinalVariableName/Example2/list-of-projects.properties
+++ b/LocalFinalVariableName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalFinalVariableName/Example2/list-of-projects.yml
+++ b/LocalFinalVariableName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalFinalVariableName/Example3/list-of-projects.properties
+++ b/LocalFinalVariableName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalFinalVariableName/Example3/list-of-projects.yml
+++ b/LocalFinalVariableName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalFinalVariableName/all-examples-in-one/list-of-projects.properties
+++ b/LocalFinalVariableName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalFinalVariableName/all-examples-in-one/list-of-projects.yml
+++ b/LocalFinalVariableName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalVariableName/Example1/list-of-projects.properties
+++ b/LocalVariableName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalVariableName/Example1/list-of-projects.yml
+++ b/LocalVariableName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalVariableName/Example2/list-of-projects.properties
+++ b/LocalVariableName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalVariableName/Example2/list-of-projects.yml
+++ b/LocalVariableName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalVariableName/Example3/list-of-projects.properties
+++ b/LocalVariableName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalVariableName/Example3/list-of-projects.yml
+++ b/LocalVariableName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalVariableName/Example4/list-of-projects.properties
+++ b/LocalVariableName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalVariableName/Example4/list-of-projects.yml
+++ b/LocalVariableName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalVariableName/Example5/list-of-projects.properties
+++ b/LocalVariableName/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalVariableName/Example5/list-of-projects.yml
+++ b/LocalVariableName/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/LocalVariableName/all-examples-in-one/list-of-projects.properties
+++ b/LocalVariableName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/LocalVariableName/all-examples-in-one/list-of-projects.yml
+++ b/LocalVariableName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MagicNumber/Example1/list-of-projects.properties
+++ b/MagicNumber/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MagicNumber/Example1/list-of-projects.yml
+++ b/MagicNumber/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MagicNumber/Example2/list-of-projects.properties
+++ b/MagicNumber/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MagicNumber/Example2/list-of-projects.yml
+++ b/MagicNumber/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MagicNumber/Example3/list-of-projects.properties
+++ b/MagicNumber/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MagicNumber/Example3/list-of-projects.yml
+++ b/MagicNumber/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MagicNumber/Example4/list-of-projects.properties
+++ b/MagicNumber/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MagicNumber/Example4/list-of-projects.yml
+++ b/MagicNumber/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MagicNumber/Example5/list-of-projects.properties
+++ b/MagicNumber/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MagicNumber/Example5/list-of-projects.yml
+++ b/MagicNumber/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MagicNumber/Example6/list-of-projects.properties
+++ b/MagicNumber/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MagicNumber/Example6/list-of-projects.yml
+++ b/MagicNumber/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MagicNumber/all-examples-in-one/list-of-projects.properties
+++ b/MagicNumber/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MagicNumber/all-examples-in-one/list-of-projects.yml
+++ b/MagicNumber/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MatchXpath/Example1/list-of-projects.properties
+++ b/MatchXpath/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MatchXpath/Example1/list-of-projects.yml
+++ b/MatchXpath/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MatchXpath/Example2/list-of-projects.properties
+++ b/MatchXpath/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MatchXpath/Example2/list-of-projects.yml
+++ b/MatchXpath/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MatchXpath/Example3/list-of-projects.properties
+++ b/MatchXpath/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MatchXpath/Example3/list-of-projects.yml
+++ b/MatchXpath/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MatchXpath/Example4/list-of-projects.properties
+++ b/MatchXpath/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MatchXpath/Example4/list-of-projects.yml
+++ b/MatchXpath/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MatchXpath/Example5/list-of-projects.properties
+++ b/MatchXpath/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MatchXpath/Example5/list-of-projects.yml
+++ b/MatchXpath/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MatchXpath/Example6/list-of-projects.properties
+++ b/MatchXpath/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MatchXpath/Example6/list-of-projects.yml
+++ b/MatchXpath/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MatchXpath/all-examples-in-one/list-of-projects.properties
+++ b/MatchXpath/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MatchXpath/all-examples-in-one/list-of-projects.yml
+++ b/MatchXpath/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MemberName/Example1/list-of-projects.properties
+++ b/MemberName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MemberName/Example1/list-of-projects.yml
+++ b/MemberName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MemberName/Example2/list-of-projects.properties
+++ b/MemberName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MemberName/Example2/list-of-projects.yml
+++ b/MemberName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MemberName/Example3/list-of-projects.properties
+++ b/MemberName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MemberName/Example3/list-of-projects.yml
+++ b/MemberName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MemberName/all-examples-in-one/list-of-projects.properties
+++ b/MemberName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MemberName/all-examples-in-one/list-of-projects.yml
+++ b/MemberName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodCount/Example1/list-of-projects.properties
+++ b/MethodCount/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodCount/Example1/list-of-projects.yml
+++ b/MethodCount/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodCount/Example2/list-of-projects.properties
+++ b/MethodCount/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodCount/Example2/list-of-projects.yml
+++ b/MethodCount/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodCount/Example3/list-of-projects.properties
+++ b/MethodCount/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodCount/Example3/list-of-projects.yml
+++ b/MethodCount/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodCount/Example4/list-of-projects.properties
+++ b/MethodCount/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodCount/Example4/list-of-projects.yml
+++ b/MethodCount/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodCount/Example5/list-of-projects.properties
+++ b/MethodCount/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodCount/Example5/list-of-projects.yml
+++ b/MethodCount/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodCount/Example6/list-of-projects.properties
+++ b/MethodCount/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodCount/Example6/list-of-projects.yml
+++ b/MethodCount/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodCount/all-examples-in-one/list-of-projects.properties
+++ b/MethodCount/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodCount/all-examples-in-one/list-of-projects.yml
+++ b/MethodCount/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodLength/Example1/list-of-projects.properties
+++ b/MethodLength/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodLength/Example1/list-of-projects.yml
+++ b/MethodLength/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodLength/Example2/list-of-projects.properties
+++ b/MethodLength/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodLength/Example2/list-of-projects.yml
+++ b/MethodLength/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodLength/Example3/list-of-projects.properties
+++ b/MethodLength/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodLength/Example3/list-of-projects.yml
+++ b/MethodLength/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodLength/all-examples-in-one/list-of-projects.properties
+++ b/MethodLength/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodLength/all-examples-in-one/list-of-projects.yml
+++ b/MethodLength/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/Example1/list-of-projects.properties
+++ b/MethodName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/Example1/list-of-projects.yml
+++ b/MethodName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/Example2/list-of-projects.properties
+++ b/MethodName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/Example2/list-of-projects.yml
+++ b/MethodName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/Example3/list-of-projects.properties
+++ b/MethodName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/Example3/list-of-projects.yml
+++ b/MethodName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/Example4/list-of-projects.properties
+++ b/MethodName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/Example4/list-of-projects.yml
+++ b/MethodName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/Example5/list-of-projects.properties
+++ b/MethodName/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/Example5/list-of-projects.yml
+++ b/MethodName/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/Example6/list-of-projects.properties
+++ b/MethodName/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/Example6/list-of-projects.yml
+++ b/MethodName/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/Example7/list-of-projects.properties
+++ b/MethodName/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/Example7/list-of-projects.yml
+++ b/MethodName/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodName/all-examples-in-one/list-of-projects.properties
+++ b/MethodName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodName/all-examples-in-one/list-of-projects.yml
+++ b/MethodName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodParamPad/Example1/list-of-projects.properties
+++ b/MethodParamPad/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodParamPad/Example1/list-of-projects.yml
+++ b/MethodParamPad/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodParamPad/Example2/list-of-projects.properties
+++ b/MethodParamPad/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodParamPad/Example2/list-of-projects.yml
+++ b/MethodParamPad/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodParamPad/all-examples-in-one/list-of-projects.properties
+++ b/MethodParamPad/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodParamPad/all-examples-in-one/list-of-projects.yml
+++ b/MethodParamPad/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodTypeParameterName/Example1/list-of-projects.properties
+++ b/MethodTypeParameterName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodTypeParameterName/Example1/list-of-projects.yml
+++ b/MethodTypeParameterName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodTypeParameterName/Example2/list-of-projects.properties
+++ b/MethodTypeParameterName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodTypeParameterName/Example2/list-of-projects.yml
+++ b/MethodTypeParameterName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MethodTypeParameterName/all-examples-in-one/list-of-projects.properties
+++ b/MethodTypeParameterName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MethodTypeParameterName/all-examples-in-one/list-of-projects.yml
+++ b/MethodTypeParameterName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingCtor/Example1/list-of-projects.properties
+++ b/MissingCtor/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingCtor/Example1/list-of-projects.yml
+++ b/MissingCtor/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingCtor/all-examples-in-one/list-of-projects.properties
+++ b/MissingCtor/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingCtor/all-examples-in-one/list-of-projects.yml
+++ b/MissingCtor/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingDeprecated/Example1/list-of-projects.properties
+++ b/MissingDeprecated/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingDeprecated/Example1/list-of-projects.yml
+++ b/MissingDeprecated/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingDeprecated/Example2/list-of-projects.properties
+++ b/MissingDeprecated/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingDeprecated/Example2/list-of-projects.yml
+++ b/MissingDeprecated/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingDeprecated/all-examples-in-one/list-of-projects.properties
+++ b/MissingDeprecated/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingDeprecated/all-examples-in-one/list-of-projects.yml
+++ b/MissingDeprecated/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/Example1/list-of-projects.properties
+++ b/MissingJavadocMethod/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/Example1/list-of-projects.yml
+++ b/MissingJavadocMethod/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/Example2/list-of-projects.properties
+++ b/MissingJavadocMethod/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/Example2/list-of-projects.yml
+++ b/MissingJavadocMethod/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/Example3/list-of-projects.properties
+++ b/MissingJavadocMethod/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/Example3/list-of-projects.yml
+++ b/MissingJavadocMethod/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/Example4/list-of-projects.properties
+++ b/MissingJavadocMethod/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/Example4/list-of-projects.yml
+++ b/MissingJavadocMethod/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/Example5/list-of-projects.properties
+++ b/MissingJavadocMethod/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/Example5/list-of-projects.yml
+++ b/MissingJavadocMethod/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/Example6/list-of-projects.properties
+++ b/MissingJavadocMethod/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/Example6/list-of-projects.yml
+++ b/MissingJavadocMethod/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/Example7/list-of-projects.properties
+++ b/MissingJavadocMethod/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/Example7/list-of-projects.yml
+++ b/MissingJavadocMethod/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocMethod/all-examples-in-one/list-of-projects.properties
+++ b/MissingJavadocMethod/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocMethod/all-examples-in-one/list-of-projects.yml
+++ b/MissingJavadocMethod/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocType/Example1/list-of-projects.properties
+++ b/MissingJavadocType/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocType/Example1/list-of-projects.yml
+++ b/MissingJavadocType/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocType/Example2/list-of-projects.properties
+++ b/MissingJavadocType/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocType/Example2/list-of-projects.yml
+++ b/MissingJavadocType/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocType/Example3/list-of-projects.properties
+++ b/MissingJavadocType/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocType/Example3/list-of-projects.yml
+++ b/MissingJavadocType/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocType/Example4/list-of-projects.properties
+++ b/MissingJavadocType/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocType/Example4/list-of-projects.yml
+++ b/MissingJavadocType/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocType/Example5/list-of-projects.properties
+++ b/MissingJavadocType/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocType/Example5/list-of-projects.yml
+++ b/MissingJavadocType/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingJavadocType/all-examples-in-one/list-of-projects.properties
+++ b/MissingJavadocType/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingJavadocType/all-examples-in-one/list-of-projects.yml
+++ b/MissingJavadocType/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingNullCaseInSwitch/Example1/list-of-projects.properties
+++ b/MissingNullCaseInSwitch/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingNullCaseInSwitch/Example1/list-of-projects.yml
+++ b/MissingNullCaseInSwitch/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingNullCaseInSwitch/all-examples-in-one/list-of-projects.properties
+++ b/MissingNullCaseInSwitch/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingNullCaseInSwitch/all-examples-in-one/list-of-projects.yml
+++ b/MissingNullCaseInSwitch/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingOverride/Example1/list-of-projects.properties
+++ b/MissingOverride/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingOverride/Example1/list-of-projects.yml
+++ b/MissingOverride/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingOverride/Example2/list-of-projects.properties
+++ b/MissingOverride/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingOverride/Example2/list-of-projects.yml
+++ b/MissingOverride/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingOverride/all-examples-in-one/list-of-projects.properties
+++ b/MissingOverride/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingOverride/all-examples-in-one/list-of-projects.yml
+++ b/MissingOverride/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingOverrideOnRecordAccessor/Example1/list-of-projects.properties
+++ b/MissingOverrideOnRecordAccessor/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingOverrideOnRecordAccessor/Example1/list-of-projects.yml
+++ b/MissingOverrideOnRecordAccessor/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingOverrideOnRecordAccessor/Example2/list-of-projects.properties
+++ b/MissingOverrideOnRecordAccessor/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingOverrideOnRecordAccessor/Example2/list-of-projects.yml
+++ b/MissingOverrideOnRecordAccessor/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingOverrideOnRecordAccessor/all-examples-in-one/list-of-projects.properties
+++ b/MissingOverrideOnRecordAccessor/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingOverrideOnRecordAccessor/all-examples-in-one/list-of-projects.yml
+++ b/MissingOverrideOnRecordAccessor/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingSwitchDefault/Example1/list-of-projects.properties
+++ b/MissingSwitchDefault/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingSwitchDefault/Example1/list-of-projects.yml
+++ b/MissingSwitchDefault/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingSwitchDefault/Example2/list-of-projects.properties
+++ b/MissingSwitchDefault/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingSwitchDefault/Example2/list-of-projects.yml
+++ b/MissingSwitchDefault/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingSwitchDefault/Example3/list-of-projects.properties
+++ b/MissingSwitchDefault/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingSwitchDefault/Example3/list-of-projects.yml
+++ b/MissingSwitchDefault/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MissingSwitchDefault/all-examples-in-one/list-of-projects.properties
+++ b/MissingSwitchDefault/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MissingSwitchDefault/all-examples-in-one/list-of-projects.yml
+++ b/MissingSwitchDefault/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ModifiedControlVariable/Example1/list-of-projects.properties
+++ b/ModifiedControlVariable/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ModifiedControlVariable/Example1/list-of-projects.yml
+++ b/ModifiedControlVariable/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ModifiedControlVariable/Example2/list-of-projects.properties
+++ b/ModifiedControlVariable/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ModifiedControlVariable/Example2/list-of-projects.yml
+++ b/ModifiedControlVariable/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ModifiedControlVariable/all-examples-in-one/list-of-projects.properties
+++ b/ModifiedControlVariable/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ModifiedControlVariable/all-examples-in-one/list-of-projects.yml
+++ b/ModifiedControlVariable/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ModifierOrder/Example1/list-of-projects.properties
+++ b/ModifierOrder/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ModifierOrder/Example1/list-of-projects.yml
+++ b/ModifierOrder/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ModifierOrder/all-examples-in-one/list-of-projects.properties
+++ b/ModifierOrder/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ModifierOrder/all-examples-in-one/list-of-projects.yml
+++ b/ModifierOrder/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultiFileRegexpHeader/Example1/list-of-projects.properties
+++ b/MultiFileRegexpHeader/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultiFileRegexpHeader/Example1/list-of-projects.yml
+++ b/MultiFileRegexpHeader/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultiFileRegexpHeader/Example2/list-of-projects.properties
+++ b/MultiFileRegexpHeader/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultiFileRegexpHeader/Example2/list-of-projects.yml
+++ b/MultiFileRegexpHeader/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultiFileRegexpHeader/Example3/list-of-projects.properties
+++ b/MultiFileRegexpHeader/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultiFileRegexpHeader/Example3/list-of-projects.yml
+++ b/MultiFileRegexpHeader/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultiFileRegexpHeader/Example4/list-of-projects.properties
+++ b/MultiFileRegexpHeader/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultiFileRegexpHeader/Example4/list-of-projects.yml
+++ b/MultiFileRegexpHeader/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultiFileRegexpHeader/all-examples-in-one/list-of-projects.properties
+++ b/MultiFileRegexpHeader/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultiFileRegexpHeader/all-examples-in-one/list-of-projects.yml
+++ b/MultiFileRegexpHeader/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultipleStringLiterals/Example1/list-of-projects.properties
+++ b/MultipleStringLiterals/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultipleStringLiterals/Example1/list-of-projects.yml
+++ b/MultipleStringLiterals/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultipleStringLiterals/Example2/list-of-projects.properties
+++ b/MultipleStringLiterals/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultipleStringLiterals/Example2/list-of-projects.yml
+++ b/MultipleStringLiterals/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultipleStringLiterals/Example3/list-of-projects.properties
+++ b/MultipleStringLiterals/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultipleStringLiterals/Example3/list-of-projects.yml
+++ b/MultipleStringLiterals/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultipleStringLiterals/Example4/list-of-projects.properties
+++ b/MultipleStringLiterals/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultipleStringLiterals/Example4/list-of-projects.yml
+++ b/MultipleStringLiterals/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultipleStringLiterals/all-examples-in-one/list-of-projects.properties
+++ b/MultipleStringLiterals/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultipleStringLiterals/all-examples-in-one/list-of-projects.yml
+++ b/MultipleStringLiterals/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultipleVariableDeclarations/Example1/list-of-projects.properties
+++ b/MultipleVariableDeclarations/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultipleVariableDeclarations/Example1/list-of-projects.yml
+++ b/MultipleVariableDeclarations/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MultipleVariableDeclarations/all-examples-in-one/list-of-projects.properties
+++ b/MultipleVariableDeclarations/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MultipleVariableDeclarations/all-examples-in-one/list-of-projects.yml
+++ b/MultipleVariableDeclarations/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MutableException/Example1/list-of-projects.properties
+++ b/MutableException/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MutableException/Example1/list-of-projects.yml
+++ b/MutableException/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MutableException/Example2/list-of-projects.properties
+++ b/MutableException/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MutableException/Example2/list-of-projects.yml
+++ b/MutableException/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MutableException/Example3/list-of-projects.properties
+++ b/MutableException/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MutableException/Example3/list-of-projects.yml
+++ b/MutableException/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/MutableException/all-examples-in-one/list-of-projects.properties
+++ b/MutableException/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/MutableException/all-examples-in-one/list-of-projects.yml
+++ b/MutableException/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NPathComplexity/Example1/list-of-projects.properties
+++ b/NPathComplexity/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NPathComplexity/Example1/list-of-projects.yml
+++ b/NPathComplexity/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NPathComplexity/Example2/list-of-projects.properties
+++ b/NPathComplexity/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NPathComplexity/Example2/list-of-projects.yml
+++ b/NPathComplexity/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NPathComplexity/all-examples-in-one/list-of-projects.properties
+++ b/NPathComplexity/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NPathComplexity/all-examples-in-one/list-of-projects.yml
+++ b/NPathComplexity/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NeedBraces/Example1/list-of-projects.properties
+++ b/NeedBraces/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NeedBraces/Example1/list-of-projects.yml
+++ b/NeedBraces/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NeedBraces/Example2/list-of-projects.properties
+++ b/NeedBraces/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NeedBraces/Example2/list-of-projects.yml
+++ b/NeedBraces/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NeedBraces/Example3/list-of-projects.properties
+++ b/NeedBraces/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NeedBraces/Example3/list-of-projects.yml
+++ b/NeedBraces/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NeedBraces/Example4/list-of-projects.properties
+++ b/NeedBraces/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NeedBraces/Example4/list-of-projects.yml
+++ b/NeedBraces/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NeedBraces/Example5/list-of-projects.properties
+++ b/NeedBraces/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NeedBraces/Example5/list-of-projects.yml
+++ b/NeedBraces/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NeedBraces/Example6/list-of-projects.properties
+++ b/NeedBraces/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NeedBraces/Example6/list-of-projects.yml
+++ b/NeedBraces/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NeedBraces/all-examples-in-one/list-of-projects.properties
+++ b/NeedBraces/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NeedBraces/all-examples-in-one/list-of-projects.yml
+++ b/NeedBraces/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedForDepth/Example1/list-of-projects.properties
+++ b/NestedForDepth/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedForDepth/Example1/list-of-projects.yml
+++ b/NestedForDepth/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedForDepth/Example2/list-of-projects.properties
+++ b/NestedForDepth/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedForDepth/Example2/list-of-projects.yml
+++ b/NestedForDepth/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedForDepth/all-examples-in-one/list-of-projects.properties
+++ b/NestedForDepth/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedForDepth/all-examples-in-one/list-of-projects.yml
+++ b/NestedForDepth/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedIfDepth/Example1/list-of-projects.properties
+++ b/NestedIfDepth/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedIfDepth/Example1/list-of-projects.yml
+++ b/NestedIfDepth/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedIfDepth/Example2/list-of-projects.properties
+++ b/NestedIfDepth/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedIfDepth/Example2/list-of-projects.yml
+++ b/NestedIfDepth/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedIfDepth/all-examples-in-one/list-of-projects.properties
+++ b/NestedIfDepth/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedIfDepth/all-examples-in-one/list-of-projects.yml
+++ b/NestedIfDepth/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedTryDepth/Example1/list-of-projects.properties
+++ b/NestedTryDepth/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedTryDepth/Example1/list-of-projects.yml
+++ b/NestedTryDepth/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedTryDepth/Example2/list-of-projects.properties
+++ b/NestedTryDepth/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedTryDepth/Example2/list-of-projects.yml
+++ b/NestedTryDepth/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NestedTryDepth/all-examples-in-one/list-of-projects.properties
+++ b/NestedTryDepth/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NestedTryDepth/all-examples-in-one/list-of-projects.yml
+++ b/NestedTryDepth/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NewlineAtEndOfFile/Example1/list-of-projects.properties
+++ b/NewlineAtEndOfFile/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NewlineAtEndOfFile/Example1/list-of-projects.yml
+++ b/NewlineAtEndOfFile/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NewlineAtEndOfFile/Example2/list-of-projects.properties
+++ b/NewlineAtEndOfFile/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NewlineAtEndOfFile/Example2/list-of-projects.yml
+++ b/NewlineAtEndOfFile/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NewlineAtEndOfFile/Example3/list-of-projects.properties
+++ b/NewlineAtEndOfFile/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NewlineAtEndOfFile/Example3/list-of-projects.yml
+++ b/NewlineAtEndOfFile/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NewlineAtEndOfFile/Example5/list-of-projects.properties
+++ b/NewlineAtEndOfFile/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NewlineAtEndOfFile/Example5/list-of-projects.yml
+++ b/NewlineAtEndOfFile/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NewlineAtEndOfFile/Example6/list-of-projects.properties
+++ b/NewlineAtEndOfFile/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NewlineAtEndOfFile/Example6/list-of-projects.yml
+++ b/NewlineAtEndOfFile/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NewlineAtEndOfFile/all-examples-in-one/list-of-projects.properties
+++ b/NewlineAtEndOfFile/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NewlineAtEndOfFile/all-examples-in-one/list-of-projects.yml
+++ b/NewlineAtEndOfFile/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoArrayTrailingComma/Example1/list-of-projects.properties
+++ b/NoArrayTrailingComma/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoArrayTrailingComma/Example1/list-of-projects.yml
+++ b/NoArrayTrailingComma/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoArrayTrailingComma/all-examples-in-one/list-of-projects.properties
+++ b/NoArrayTrailingComma/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoArrayTrailingComma/all-examples-in-one/list-of-projects.yml
+++ b/NoArrayTrailingComma/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoClone/Example1/list-of-projects.properties
+++ b/NoClone/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoClone/Example1/list-of-projects.yml
+++ b/NoClone/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoClone/all-examples-in-one/list-of-projects.properties
+++ b/NoClone/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoClone/all-examples-in-one/list-of-projects.yml
+++ b/NoClone/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoCodeInFile/Example1/list-of-projects.properties
+++ b/NoCodeInFile/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoCodeInFile/Example1/list-of-projects.yml
+++ b/NoCodeInFile/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoCodeInFile/Example2/list-of-projects.properties
+++ b/NoCodeInFile/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoCodeInFile/Example2/list-of-projects.yml
+++ b/NoCodeInFile/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoCodeInFile/all-examples-in-one/list-of-projects.properties
+++ b/NoCodeInFile/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoCodeInFile/all-examples-in-one/list-of-projects.yml
+++ b/NoCodeInFile/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoEnumTrailingComma/Example1/list-of-projects.properties
+++ b/NoEnumTrailingComma/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoEnumTrailingComma/Example1/list-of-projects.yml
+++ b/NoEnumTrailingComma/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoEnumTrailingComma/all-examples-in-one/list-of-projects.properties
+++ b/NoEnumTrailingComma/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoEnumTrailingComma/all-examples-in-one/list-of-projects.yml
+++ b/NoEnumTrailingComma/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoFinalizer/Example1/list-of-projects.properties
+++ b/NoFinalizer/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoFinalizer/Example1/list-of-projects.yml
+++ b/NoFinalizer/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoFinalizer/all-examples-in-one/list-of-projects.properties
+++ b/NoFinalizer/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoFinalizer/all-examples-in-one/list-of-projects.yml
+++ b/NoFinalizer/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoLineWrap/Example1/list-of-projects.properties
+++ b/NoLineWrap/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoLineWrap/Example1/list-of-projects.yml
+++ b/NoLineWrap/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoLineWrap/Example2/list-of-projects.properties
+++ b/NoLineWrap/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoLineWrap/Example2/list-of-projects.yml
+++ b/NoLineWrap/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoLineWrap/Example3/list-of-projects.properties
+++ b/NoLineWrap/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoLineWrap/Example3/list-of-projects.yml
+++ b/NoLineWrap/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoLineWrap/all-examples-in-one/list-of-projects.properties
+++ b/NoLineWrap/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoLineWrap/all-examples-in-one/list-of-projects.yml
+++ b/NoLineWrap/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceAfter/Example1/list-of-projects.properties
+++ b/NoWhitespaceAfter/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceAfter/Example1/list-of-projects.yml
+++ b/NoWhitespaceAfter/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceAfter/Example2/list-of-projects.properties
+++ b/NoWhitespaceAfter/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceAfter/Example2/list-of-projects.yml
+++ b/NoWhitespaceAfter/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceAfter/all-examples-in-one/list-of-projects.properties
+++ b/NoWhitespaceAfter/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceAfter/all-examples-in-one/list-of-projects.yml
+++ b/NoWhitespaceAfter/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceBefore/Example1/list-of-projects.properties
+++ b/NoWhitespaceBefore/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceBefore/Example1/list-of-projects.yml
+++ b/NoWhitespaceBefore/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceBefore/Example2/list-of-projects.properties
+++ b/NoWhitespaceBefore/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceBefore/Example2/list-of-projects.yml
+++ b/NoWhitespaceBefore/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceBefore/Example3/list-of-projects.properties
+++ b/NoWhitespaceBefore/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceBefore/Example3/list-of-projects.yml
+++ b/NoWhitespaceBefore/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceBefore/Example4/list-of-projects.properties
+++ b/NoWhitespaceBefore/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceBefore/Example4/list-of-projects.yml
+++ b/NoWhitespaceBefore/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceBefore/all-examples-in-one/list-of-projects.properties
+++ b/NoWhitespaceBefore/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceBefore/all-examples-in-one/list-of-projects.yml
+++ b/NoWhitespaceBefore/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceBeforeCaseDefaultColon/Example1/list-of-projects.properties
+++ b/NoWhitespaceBeforeCaseDefaultColon/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceBeforeCaseDefaultColon/Example1/list-of-projects.yml
+++ b/NoWhitespaceBeforeCaseDefaultColon/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NoWhitespaceBeforeCaseDefaultColon/all-examples-in-one/list-of-projects.properties
+++ b/NoWhitespaceBeforeCaseDefaultColon/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NoWhitespaceBeforeCaseDefaultColon/all-examples-in-one/list-of-projects.yml
+++ b/NoWhitespaceBeforeCaseDefaultColon/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NonEmptyAtclauseDescription/Example1/list-of-projects.properties
+++ b/NonEmptyAtclauseDescription/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NonEmptyAtclauseDescription/Example1/list-of-projects.yml
+++ b/NonEmptyAtclauseDescription/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NonEmptyAtclauseDescription/Example2/list-of-projects.properties
+++ b/NonEmptyAtclauseDescription/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NonEmptyAtclauseDescription/Example2/list-of-projects.yml
+++ b/NonEmptyAtclauseDescription/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NonEmptyAtclauseDescription/all-examples-in-one/list-of-projects.properties
+++ b/NonEmptyAtclauseDescription/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NonEmptyAtclauseDescription/all-examples-in-one/list-of-projects.yml
+++ b/NonEmptyAtclauseDescription/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NumericalPrefixesInfixesSuffixesCharacterCase/Example1/list-of-projects.properties
+++ b/NumericalPrefixesInfixesSuffixesCharacterCase/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NumericalPrefixesInfixesSuffixesCharacterCase/Example1/list-of-projects.yml
+++ b/NumericalPrefixesInfixesSuffixesCharacterCase/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/NumericalPrefixesInfixesSuffixesCharacterCase/all-examples-in-one/list-of-projects.properties
+++ b/NumericalPrefixesInfixesSuffixesCharacterCase/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/NumericalPrefixesInfixesSuffixesCharacterCase/all-examples-in-one/list-of-projects.yml
+++ b/NumericalPrefixesInfixesSuffixesCharacterCase/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OneStatementPerLine/Example1/list-of-projects.properties
+++ b/OneStatementPerLine/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OneStatementPerLine/Example1/list-of-projects.yml
+++ b/OneStatementPerLine/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OneStatementPerLine/Example2/list-of-projects.properties
+++ b/OneStatementPerLine/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OneStatementPerLine/Example2/list-of-projects.yml
+++ b/OneStatementPerLine/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OneStatementPerLine/all-examples-in-one/list-of-projects.properties
+++ b/OneStatementPerLine/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OneStatementPerLine/all-examples-in-one/list-of-projects.yml
+++ b/OneStatementPerLine/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OneTopLevelClass/Example1/list-of-projects.properties
+++ b/OneTopLevelClass/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OneTopLevelClass/Example1/list-of-projects.yml
+++ b/OneTopLevelClass/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OneTopLevelClass/Example2/list-of-projects.properties
+++ b/OneTopLevelClass/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OneTopLevelClass/Example2/list-of-projects.yml
+++ b/OneTopLevelClass/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OneTopLevelClass/Example3/list-of-projects.properties
+++ b/OneTopLevelClass/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OneTopLevelClass/Example3/list-of-projects.yml
+++ b/OneTopLevelClass/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OneTopLevelClass/all-examples-in-one/list-of-projects.properties
+++ b/OneTopLevelClass/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OneTopLevelClass/all-examples-in-one/list-of-projects.yml
+++ b/OneTopLevelClass/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OperatorWrap/Example1/list-of-projects.properties
+++ b/OperatorWrap/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OperatorWrap/Example1/list-of-projects.yml
+++ b/OperatorWrap/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OperatorWrap/Example2/list-of-projects.properties
+++ b/OperatorWrap/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OperatorWrap/Example2/list-of-projects.yml
+++ b/OperatorWrap/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OperatorWrap/all-examples-in-one/list-of-projects.properties
+++ b/OperatorWrap/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OperatorWrap/all-examples-in-one/list-of-projects.yml
+++ b/OperatorWrap/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OrderedProperties/Example1/list-of-projects.properties
+++ b/OrderedProperties/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OrderedProperties/Example1/list-of-projects.yml
+++ b/OrderedProperties/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OrderedProperties/all-examples-in-one/list-of-projects.properties
+++ b/OrderedProperties/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OrderedProperties/all-examples-in-one/list-of-projects.yml
+++ b/OrderedProperties/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeFilename/Example1/list-of-projects.properties
+++ b/OuterTypeFilename/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeFilename/Example1/list-of-projects.yml
+++ b/OuterTypeFilename/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeFilename/Example2/list-of-projects.properties
+++ b/OuterTypeFilename/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeFilename/Example2/list-of-projects.yml
+++ b/OuterTypeFilename/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeFilename/Example3/list-of-projects.properties
+++ b/OuterTypeFilename/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeFilename/Example3/list-of-projects.yml
+++ b/OuterTypeFilename/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeFilename/Example4/list-of-projects.properties
+++ b/OuterTypeFilename/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeFilename/Example4/list-of-projects.yml
+++ b/OuterTypeFilename/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeFilename/Example5/list-of-projects.properties
+++ b/OuterTypeFilename/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeFilename/Example5/list-of-projects.yml
+++ b/OuterTypeFilename/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeFilename/all-examples-in-one/list-of-projects.properties
+++ b/OuterTypeFilename/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeFilename/all-examples-in-one/list-of-projects.yml
+++ b/OuterTypeFilename/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeNumber/Example1/list-of-projects.properties
+++ b/OuterTypeNumber/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeNumber/Example1/list-of-projects.yml
+++ b/OuterTypeNumber/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeNumber/Example2/list-of-projects.properties
+++ b/OuterTypeNumber/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeNumber/Example2/list-of-projects.yml
+++ b/OuterTypeNumber/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OuterTypeNumber/all-examples-in-one/list-of-projects.properties
+++ b/OuterTypeNumber/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OuterTypeNumber/all-examples-in-one/list-of-projects.yml
+++ b/OuterTypeNumber/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OverloadMethodsDeclarationOrder/Example1/list-of-projects.properties
+++ b/OverloadMethodsDeclarationOrder/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OverloadMethodsDeclarationOrder/Example1/list-of-projects.yml
+++ b/OverloadMethodsDeclarationOrder/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OverloadMethodsDeclarationOrder/Example2/list-of-projects.properties
+++ b/OverloadMethodsDeclarationOrder/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OverloadMethodsDeclarationOrder/Example2/list-of-projects.yml
+++ b/OverloadMethodsDeclarationOrder/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/OverloadMethodsDeclarationOrder/all-examples-in-one/list-of-projects.properties
+++ b/OverloadMethodsDeclarationOrder/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/OverloadMethodsDeclarationOrder/all-examples-in-one/list-of-projects.yml
+++ b/OverloadMethodsDeclarationOrder/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageAnnotation/Example1/list-of-projects.properties
+++ b/PackageAnnotation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageAnnotation/Example1/list-of-projects.yml
+++ b/PackageAnnotation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageAnnotation/Example2/list-of-projects.properties
+++ b/PackageAnnotation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageAnnotation/Example2/list-of-projects.yml
+++ b/PackageAnnotation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageAnnotation/all-examples-in-one/list-of-projects.properties
+++ b/PackageAnnotation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageAnnotation/all-examples-in-one/list-of-projects.yml
+++ b/PackageAnnotation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageDeclaration/Example1/list-of-projects.properties
+++ b/PackageDeclaration/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageDeclaration/Example1/list-of-projects.yml
+++ b/PackageDeclaration/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageDeclaration/Example2/list-of-projects.properties
+++ b/PackageDeclaration/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageDeclaration/Example2/list-of-projects.yml
+++ b/PackageDeclaration/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageDeclaration/all-examples-in-one/list-of-projects.properties
+++ b/PackageDeclaration/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageDeclaration/all-examples-in-one/list-of-projects.yml
+++ b/PackageDeclaration/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageName/Example1/list-of-projects.properties
+++ b/PackageName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageName/Example1/list-of-projects.yml
+++ b/PackageName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageName/Example2/list-of-projects.properties
+++ b/PackageName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageName/Example2/list-of-projects.yml
+++ b/PackageName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PackageName/all-examples-in-one/list-of-projects.properties
+++ b/PackageName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PackageName/all-examples-in-one/list-of-projects.yml
+++ b/PackageName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterAssignment/Example1/list-of-projects.properties
+++ b/ParameterAssignment/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterAssignment/Example1/list-of-projects.yml
+++ b/ParameterAssignment/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterAssignment/all-examples-in-one/list-of-projects.properties
+++ b/ParameterAssignment/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterAssignment/all-examples-in-one/list-of-projects.yml
+++ b/ParameterAssignment/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterName/Example1/list-of-projects.properties
+++ b/ParameterName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterName/Example1/list-of-projects.yml
+++ b/ParameterName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterName/Example2/list-of-projects.properties
+++ b/ParameterName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterName/Example2/list-of-projects.yml
+++ b/ParameterName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterName/Example3/list-of-projects.properties
+++ b/ParameterName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterName/Example3/list-of-projects.yml
+++ b/ParameterName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterName/Example4/list-of-projects.properties
+++ b/ParameterName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterName/Example4/list-of-projects.yml
+++ b/ParameterName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterName/Example5/list-of-projects.properties
+++ b/ParameterName/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterName/Example5/list-of-projects.yml
+++ b/ParameterName/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterName/all-examples-in-one/list-of-projects.properties
+++ b/ParameterName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterName/all-examples-in-one/list-of-projects.yml
+++ b/ParameterName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterNumber/Example1/list-of-projects.properties
+++ b/ParameterNumber/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterNumber/Example1/list-of-projects.yml
+++ b/ParameterNumber/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterNumber/Example2/list-of-projects.properties
+++ b/ParameterNumber/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterNumber/Example2/list-of-projects.yml
+++ b/ParameterNumber/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterNumber/Example3/list-of-projects.properties
+++ b/ParameterNumber/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterNumber/Example3/list-of-projects.yml
+++ b/ParameterNumber/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterNumber/Example4/list-of-projects.properties
+++ b/ParameterNumber/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterNumber/Example4/list-of-projects.yml
+++ b/ParameterNumber/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParameterNumber/all-examples-in-one/list-of-projects.properties
+++ b/ParameterNumber/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParameterNumber/all-examples-in-one/list-of-projects.yml
+++ b/ParameterNumber/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParenPad/Example1/list-of-projects.properties
+++ b/ParenPad/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParenPad/Example1/list-of-projects.yml
+++ b/ParenPad/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParenPad/Example2/list-of-projects.properties
+++ b/ParenPad/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParenPad/Example2/list-of-projects.yml
+++ b/ParenPad/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParenPad/Example3/list-of-projects.properties
+++ b/ParenPad/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParenPad/Example3/list-of-projects.yml
+++ b/ParenPad/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ParenPad/all-examples-in-one/list-of-projects.properties
+++ b/ParenPad/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ParenPad/all-examples-in-one/list-of-projects.yml
+++ b/ParenPad/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PatternVariableAssignment/Example1/list-of-projects.properties
+++ b/PatternVariableAssignment/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PatternVariableAssignment/Example1/list-of-projects.yml
+++ b/PatternVariableAssignment/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PatternVariableAssignment/all-examples-in-one/list-of-projects.properties
+++ b/PatternVariableAssignment/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PatternVariableAssignment/all-examples-in-one/list-of-projects.yml
+++ b/PatternVariableAssignment/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PatternVariableName/Example1/list-of-projects.properties
+++ b/PatternVariableName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PatternVariableName/Example1/list-of-projects.yml
+++ b/PatternVariableName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PatternVariableName/Example2/list-of-projects.properties
+++ b/PatternVariableName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PatternVariableName/Example2/list-of-projects.yml
+++ b/PatternVariableName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PatternVariableName/Example3/list-of-projects.properties
+++ b/PatternVariableName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PatternVariableName/Example3/list-of-projects.yml
+++ b/PatternVariableName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PatternVariableName/Example4/list-of-projects.properties
+++ b/PatternVariableName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PatternVariableName/Example4/list-of-projects.yml
+++ b/PatternVariableName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/PatternVariableName/all-examples-in-one/list-of-projects.properties
+++ b/PatternVariableName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/PatternVariableName/all-examples-in-one/list-of-projects.yml
+++ b/PatternVariableName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordComponentName/Example1/list-of-projects.properties
+++ b/RecordComponentName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordComponentName/Example1/list-of-projects.yml
+++ b/RecordComponentName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordComponentName/Example2/list-of-projects.properties
+++ b/RecordComponentName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordComponentName/Example2/list-of-projects.yml
+++ b/RecordComponentName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordComponentName/all-examples-in-one/list-of-projects.properties
+++ b/RecordComponentName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordComponentName/all-examples-in-one/list-of-projects.yml
+++ b/RecordComponentName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordComponentNumber/Example1/list-of-projects.properties
+++ b/RecordComponentNumber/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordComponentNumber/Example1/list-of-projects.yml
+++ b/RecordComponentNumber/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordComponentNumber/Example2/list-of-projects.properties
+++ b/RecordComponentNumber/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordComponentNumber/Example2/list-of-projects.yml
+++ b/RecordComponentNumber/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordComponentNumber/Example3/list-of-projects.properties
+++ b/RecordComponentNumber/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordComponentNumber/Example3/list-of-projects.yml
+++ b/RecordComponentNumber/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordComponentNumber/all-examples-in-one/list-of-projects.properties
+++ b/RecordComponentNumber/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordComponentNumber/all-examples-in-one/list-of-projects.yml
+++ b/RecordComponentNumber/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordTypeParameterName/Example1/list-of-projects.properties
+++ b/RecordTypeParameterName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordTypeParameterName/Example1/list-of-projects.yml
+++ b/RecordTypeParameterName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordTypeParameterName/Example2/list-of-projects.properties
+++ b/RecordTypeParameterName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordTypeParameterName/Example2/list-of-projects.yml
+++ b/RecordTypeParameterName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RecordTypeParameterName/all-examples-in-one/list-of-projects.properties
+++ b/RecordTypeParameterName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RecordTypeParameterName/all-examples-in-one/list-of-projects.yml
+++ b/RecordTypeParameterName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RedundantImport/Example1/list-of-projects.properties
+++ b/RedundantImport/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RedundantImport/Example1/list-of-projects.yml
+++ b/RedundantImport/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RedundantImport/Example2/list-of-projects.properties
+++ b/RedundantImport/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RedundantImport/Example2/list-of-projects.yml
+++ b/RedundantImport/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RedundantImport/all-examples-in-one/list-of-projects.properties
+++ b/RedundantImport/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RedundantImport/all-examples-in-one/list-of-projects.yml
+++ b/RedundantImport/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RedundantModifier/Example1/list-of-projects.properties
+++ b/RedundantModifier/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RedundantModifier/Example1/list-of-projects.yml
+++ b/RedundantModifier/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RedundantModifier/Example2/list-of-projects.properties
+++ b/RedundantModifier/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RedundantModifier/Example2/list-of-projects.yml
+++ b/RedundantModifier/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RedundantModifier/Example3/list-of-projects.properties
+++ b/RedundantModifier/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RedundantModifier/Example3/list-of-projects.yml
+++ b/RedundantModifier/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RedundantModifier/all-examples-in-one/list-of-projects.properties
+++ b/RedundantModifier/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RedundantModifier/all-examples-in-one/list-of-projects.yml
+++ b/RedundantModifier/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example0/list-of-projects.properties
+++ b/Regexp/Example0/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example0/list-of-projects.yml
+++ b/Regexp/Example0/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example1/list-of-projects.properties
+++ b/Regexp/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example1/list-of-projects.yml
+++ b/Regexp/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example10/list-of-projects.properties
+++ b/Regexp/Example10/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example10/list-of-projects.yml
+++ b/Regexp/Example10/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example11/list-of-projects.properties
+++ b/Regexp/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example11/list-of-projects.yml
+++ b/Regexp/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example2/list-of-projects.properties
+++ b/Regexp/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example2/list-of-projects.yml
+++ b/Regexp/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example3/list-of-projects.properties
+++ b/Regexp/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example3/list-of-projects.yml
+++ b/Regexp/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example4/list-of-projects.properties
+++ b/Regexp/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example4/list-of-projects.yml
+++ b/Regexp/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example5/list-of-projects.properties
+++ b/Regexp/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example5/list-of-projects.yml
+++ b/Regexp/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example6/list-of-projects.properties
+++ b/Regexp/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example6/list-of-projects.yml
+++ b/Regexp/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example7/list-of-projects.properties
+++ b/Regexp/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example7/list-of-projects.yml
+++ b/Regexp/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example8/list-of-projects.properties
+++ b/Regexp/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example8/list-of-projects.yml
+++ b/Regexp/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/Example9/list-of-projects.properties
+++ b/Regexp/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/Example9/list-of-projects.yml
+++ b/Regexp/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Regexp/all-examples-in-one/list-of-projects.properties
+++ b/Regexp/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Regexp/all-examples-in-one/list-of-projects.yml
+++ b/Regexp/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpHeader/Example1/list-of-projects.properties
+++ b/RegexpHeader/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpHeader/Example1/list-of-projects.yml
+++ b/RegexpHeader/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpHeader/Example2/list-of-projects.properties
+++ b/RegexpHeader/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpHeader/Example2/list-of-projects.yml
+++ b/RegexpHeader/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpHeader/Example3/list-of-projects.properties
+++ b/RegexpHeader/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpHeader/Example3/list-of-projects.yml
+++ b/RegexpHeader/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpHeader/Example4/list-of-projects.properties
+++ b/RegexpHeader/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpHeader/Example4/list-of-projects.yml
+++ b/RegexpHeader/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpHeader/all-examples-in-one/list-of-projects.properties
+++ b/RegexpHeader/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpHeader/all-examples-in-one/list-of-projects.yml
+++ b/RegexpHeader/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpMultiline/Example1/list-of-projects.properties
+++ b/RegexpMultiline/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpMultiline/Example1/list-of-projects.yml
+++ b/RegexpMultiline/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpMultiline/Example2/list-of-projects.properties
+++ b/RegexpMultiline/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpMultiline/Example2/list-of-projects.yml
+++ b/RegexpMultiline/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpMultiline/Example3/list-of-projects.properties
+++ b/RegexpMultiline/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpMultiline/Example3/list-of-projects.yml
+++ b/RegexpMultiline/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpMultiline/Example4/list-of-projects.properties
+++ b/RegexpMultiline/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpMultiline/Example4/list-of-projects.yml
+++ b/RegexpMultiline/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpMultiline/Example5/list-of-projects.properties
+++ b/RegexpMultiline/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpMultiline/Example5/list-of-projects.yml
+++ b/RegexpMultiline/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpMultiline/Example6/list-of-projects.properties
+++ b/RegexpMultiline/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpMultiline/Example6/list-of-projects.yml
+++ b/RegexpMultiline/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpMultiline/all-examples-in-one/list-of-projects.properties
+++ b/RegexpMultiline/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpMultiline/all-examples-in-one/list-of-projects.yml
+++ b/RegexpMultiline/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpOnFilename/Example1/list-of-projects.properties
+++ b/RegexpOnFilename/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpOnFilename/Example1/list-of-projects.yml
+++ b/RegexpOnFilename/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpOnFilename/Example2/list-of-projects.properties
+++ b/RegexpOnFilename/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpOnFilename/Example2/list-of-projects.yml
+++ b/RegexpOnFilename/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpOnFilename/Example3/list-of-projects.properties
+++ b/RegexpOnFilename/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpOnFilename/Example3/list-of-projects.yml
+++ b/RegexpOnFilename/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpOnFilename/Example4/list-of-projects.properties
+++ b/RegexpOnFilename/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpOnFilename/Example4/list-of-projects.yml
+++ b/RegexpOnFilename/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpOnFilename/Example5/list-of-projects.properties
+++ b/RegexpOnFilename/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpOnFilename/Example5/list-of-projects.yml
+++ b/RegexpOnFilename/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpOnFilename/all-examples-in-one/list-of-projects.properties
+++ b/RegexpOnFilename/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpOnFilename/all-examples-in-one/list-of-projects.yml
+++ b/RegexpOnFilename/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/Example1/list-of-projects.properties
+++ b/RegexpSingleline/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/Example1/list-of-projects.yml
+++ b/RegexpSingleline/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/Example2/list-of-projects.properties
+++ b/RegexpSingleline/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/Example2/list-of-projects.yml
+++ b/RegexpSingleline/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/Example3/list-of-projects.properties
+++ b/RegexpSingleline/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/Example3/list-of-projects.yml
+++ b/RegexpSingleline/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/Example4/list-of-projects.properties
+++ b/RegexpSingleline/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/Example4/list-of-projects.yml
+++ b/RegexpSingleline/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/Example5/list-of-projects.properties
+++ b/RegexpSingleline/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/Example5/list-of-projects.yml
+++ b/RegexpSingleline/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/Example6/list-of-projects.properties
+++ b/RegexpSingleline/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/Example6/list-of-projects.yml
+++ b/RegexpSingleline/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/Example7/list-of-projects.properties
+++ b/RegexpSingleline/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/Example7/list-of-projects.yml
+++ b/RegexpSingleline/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSingleline/all-examples-in-one/list-of-projects.properties
+++ b/RegexpSingleline/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSingleline/all-examples-in-one/list-of-projects.yml
+++ b/RegexpSingleline/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/Example1/list-of-projects.properties
+++ b/RegexpSinglelineJava/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/Example1/list-of-projects.yml
+++ b/RegexpSinglelineJava/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/Example2/list-of-projects.properties
+++ b/RegexpSinglelineJava/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/Example2/list-of-projects.yml
+++ b/RegexpSinglelineJava/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/Example3/list-of-projects.properties
+++ b/RegexpSinglelineJava/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/Example3/list-of-projects.yml
+++ b/RegexpSinglelineJava/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/Example4/list-of-projects.properties
+++ b/RegexpSinglelineJava/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/Example4/list-of-projects.yml
+++ b/RegexpSinglelineJava/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/Example5/list-of-projects.properties
+++ b/RegexpSinglelineJava/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/Example5/list-of-projects.yml
+++ b/RegexpSinglelineJava/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/Example6/list-of-projects.properties
+++ b/RegexpSinglelineJava/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/Example6/list-of-projects.yml
+++ b/RegexpSinglelineJava/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/Example7/list-of-projects.properties
+++ b/RegexpSinglelineJava/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/Example7/list-of-projects.yml
+++ b/RegexpSinglelineJava/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RegexpSinglelineJava/all-examples-in-one/list-of-projects.properties
+++ b/RegexpSinglelineJava/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RegexpSinglelineJava/all-examples-in-one/list-of-projects.yml
+++ b/RegexpSinglelineJava/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireEmptyLineBeforeBlockTagGroup/Example1/list-of-projects.properties
+++ b/RequireEmptyLineBeforeBlockTagGroup/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireEmptyLineBeforeBlockTagGroup/Example1/list-of-projects.yml
+++ b/RequireEmptyLineBeforeBlockTagGroup/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireEmptyLineBeforeBlockTagGroup/all-examples-in-one/list-of-projects.properties
+++ b/RequireEmptyLineBeforeBlockTagGroup/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireEmptyLineBeforeBlockTagGroup/all-examples-in-one/list-of-projects.yml
+++ b/RequireEmptyLineBeforeBlockTagGroup/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireThis/Example1/list-of-projects.properties
+++ b/RequireThis/Example1/list-of-projects.properties
@@ -28,4 +28,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireThis/Example1/list-of-projects.yml
+++ b/RequireThis/Example1/list-of-projects.yml
@@ -420,4 +420,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireThis/Example2/list-of-projects.properties
+++ b/RequireThis/Example2/list-of-projects.properties
@@ -28,4 +28,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireThis/Example2/list-of-projects.yml
+++ b/RequireThis/Example2/list-of-projects.yml
@@ -420,4 +420,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireThis/Example3/list-of-projects.properties
+++ b/RequireThis/Example3/list-of-projects.properties
@@ -28,4 +28,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireThis/Example3/list-of-projects.yml
+++ b/RequireThis/Example3/list-of-projects.yml
@@ -420,4 +420,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireThis/Example4/list-of-projects.properties
+++ b/RequireThis/Example4/list-of-projects.properties
@@ -28,4 +28,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireThis/Example4/list-of-projects.yml
+++ b/RequireThis/Example4/list-of-projects.yml
@@ -420,4 +420,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireThis/Example5/list-of-projects.properties
+++ b/RequireThis/Example5/list-of-projects.properties
@@ -28,4 +28,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireThis/Example5/list-of-projects.yml
+++ b/RequireThis/Example5/list-of-projects.yml
@@ -420,4 +420,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireThis/Example6/list-of-projects.properties
+++ b/RequireThis/Example6/list-of-projects.properties
@@ -28,4 +28,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireThis/Example6/list-of-projects.yml
+++ b/RequireThis/Example6/list-of-projects.yml
@@ -420,4 +420,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RequireThis/all-examples-in-one/list-of-projects.properties
+++ b/RequireThis/all-examples-in-one/list-of-projects.properties
@@ -28,4 +28,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RequireThis/all-examples-in-one/list-of-projects.yml
+++ b/RequireThis/all-examples-in-one/list-of-projects.yml
@@ -420,4 +420,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ReturnCount/Example1/list-of-projects.properties
+++ b/ReturnCount/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ReturnCount/Example1/list-of-projects.yml
+++ b/ReturnCount/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ReturnCount/Example2/list-of-projects.properties
+++ b/ReturnCount/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ReturnCount/Example2/list-of-projects.yml
+++ b/ReturnCount/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ReturnCount/Example3/list-of-projects.properties
+++ b/ReturnCount/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ReturnCount/Example3/list-of-projects.yml
+++ b/ReturnCount/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ReturnCount/Example4/list-of-projects.properties
+++ b/ReturnCount/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ReturnCount/Example4/list-of-projects.yml
+++ b/ReturnCount/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ReturnCount/Example5/list-of-projects.properties
+++ b/ReturnCount/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ReturnCount/Example5/list-of-projects.yml
+++ b/ReturnCount/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ReturnCount/all-examples-in-one/list-of-projects.properties
+++ b/ReturnCount/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ReturnCount/all-examples-in-one/list-of-projects.yml
+++ b/ReturnCount/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RightCurly/Example1/list-of-projects.properties
+++ b/RightCurly/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RightCurly/Example1/list-of-projects.yml
+++ b/RightCurly/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RightCurly/Example2/list-of-projects.properties
+++ b/RightCurly/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RightCurly/Example2/list-of-projects.yml
+++ b/RightCurly/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RightCurly/Example3/list-of-projects.properties
+++ b/RightCurly/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RightCurly/Example3/list-of-projects.yml
+++ b/RightCurly/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RightCurly/Example4/list-of-projects.properties
+++ b/RightCurly/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RightCurly/Example4/list-of-projects.yml
+++ b/RightCurly/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RightCurly/Example5/list-of-projects.properties
+++ b/RightCurly/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RightCurly/Example5/list-of-projects.yml
+++ b/RightCurly/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/RightCurly/all-examples-in-one/list-of-projects.properties
+++ b/RightCurly/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/RightCurly/all-examples-in-one/list-of-projects.yml
+++ b/RightCurly/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SealedShouldHavePermitsList/Example1/list-of-projects.properties
+++ b/SealedShouldHavePermitsList/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SealedShouldHavePermitsList/Example1/list-of-projects.yml
+++ b/SealedShouldHavePermitsList/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SealedShouldHavePermitsList/all-examples-in-one/list-of-projects.properties
+++ b/SealedShouldHavePermitsList/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SealedShouldHavePermitsList/all-examples-in-one/list-of-projects.yml
+++ b/SealedShouldHavePermitsList/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SeparatorWrap/Example1/list-of-projects.properties
+++ b/SeparatorWrap/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SeparatorWrap/Example1/list-of-projects.yml
+++ b/SeparatorWrap/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SeparatorWrap/Example2/list-of-projects.properties
+++ b/SeparatorWrap/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SeparatorWrap/Example2/list-of-projects.yml
+++ b/SeparatorWrap/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SeparatorWrap/Example3/list-of-projects.properties
+++ b/SeparatorWrap/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SeparatorWrap/Example3/list-of-projects.yml
+++ b/SeparatorWrap/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SeparatorWrap/all-examples-in-one/list-of-projects.properties
+++ b/SeparatorWrap/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SeparatorWrap/all-examples-in-one/list-of-projects.yml
+++ b/SeparatorWrap/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SimplifyBooleanExpression/Example1/list-of-projects.properties
+++ b/SimplifyBooleanExpression/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SimplifyBooleanExpression/Example1/list-of-projects.yml
+++ b/SimplifyBooleanExpression/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SimplifyBooleanExpression/all-examples-in-one/list-of-projects.properties
+++ b/SimplifyBooleanExpression/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SimplifyBooleanExpression/all-examples-in-one/list-of-projects.yml
+++ b/SimplifyBooleanExpression/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SimplifyBooleanReturn/Example1/list-of-projects.properties
+++ b/SimplifyBooleanReturn/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SimplifyBooleanReturn/Example1/list-of-projects.yml
+++ b/SimplifyBooleanReturn/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SimplifyBooleanReturn/all-examples-in-one/list-of-projects.properties
+++ b/SimplifyBooleanReturn/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SimplifyBooleanReturn/all-examples-in-one/list-of-projects.yml
+++ b/SimplifyBooleanReturn/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleLineJavadoc/Example1/list-of-projects.properties
+++ b/SingleLineJavadoc/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleLineJavadoc/Example1/list-of-projects.yml
+++ b/SingleLineJavadoc/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleLineJavadoc/Example2/list-of-projects.properties
+++ b/SingleLineJavadoc/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleLineJavadoc/Example2/list-of-projects.yml
+++ b/SingleLineJavadoc/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleLineJavadoc/Example3/list-of-projects.properties
+++ b/SingleLineJavadoc/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleLineJavadoc/Example3/list-of-projects.yml
+++ b/SingleLineJavadoc/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleLineJavadoc/Example4/list-of-projects.properties
+++ b/SingleLineJavadoc/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleLineJavadoc/Example4/list-of-projects.yml
+++ b/SingleLineJavadoc/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleLineJavadoc/all-examples-in-one/list-of-projects.properties
+++ b/SingleLineJavadoc/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleLineJavadoc/all-examples-in-one/list-of-projects.yml
+++ b/SingleLineJavadoc/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleSpaceSeparator/Example1/list-of-projects.properties
+++ b/SingleSpaceSeparator/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleSpaceSeparator/Example1/list-of-projects.yml
+++ b/SingleSpaceSeparator/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleSpaceSeparator/Example2/list-of-projects.properties
+++ b/SingleSpaceSeparator/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleSpaceSeparator/Example2/list-of-projects.yml
+++ b/SingleSpaceSeparator/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SingleSpaceSeparator/all-examples-in-one/list-of-projects.properties
+++ b/SingleSpaceSeparator/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SingleSpaceSeparator/all-examples-in-one/list-of-projects.yml
+++ b/SingleSpaceSeparator/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/StaticVariableName/Example1/list-of-projects.properties
+++ b/StaticVariableName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/StaticVariableName/Example1/list-of-projects.yml
+++ b/StaticVariableName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/StaticVariableName/Example2/list-of-projects.properties
+++ b/StaticVariableName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/StaticVariableName/Example2/list-of-projects.yml
+++ b/StaticVariableName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/StaticVariableName/Example3/list-of-projects.properties
+++ b/StaticVariableName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/StaticVariableName/Example3/list-of-projects.yml
+++ b/StaticVariableName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/StaticVariableName/all-examples-in-one/list-of-projects.properties
+++ b/StaticVariableName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/StaticVariableName/all-examples-in-one/list-of-projects.yml
+++ b/StaticVariableName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/StringLiteralEquality/Example1/list-of-projects.properties
+++ b/StringLiteralEquality/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/StringLiteralEquality/Example1/list-of-projects.yml
+++ b/StringLiteralEquality/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/StringLiteralEquality/all-examples-in-one/list-of-projects.properties
+++ b/StringLiteralEquality/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/StringLiteralEquality/all-examples-in-one/list-of-projects.yml
+++ b/StringLiteralEquality/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SummaryJavadoc/Example1/list-of-projects.properties
+++ b/SummaryJavadoc/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SummaryJavadoc/Example1/list-of-projects.yml
+++ b/SummaryJavadoc/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SummaryJavadoc/Example2/list-of-projects.properties
+++ b/SummaryJavadoc/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SummaryJavadoc/Example2/list-of-projects.yml
+++ b/SummaryJavadoc/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SummaryJavadoc/all-examples-in-one/list-of-projects.properties
+++ b/SummaryJavadoc/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SummaryJavadoc/all-examples-in-one/list-of-projects.yml
+++ b/SummaryJavadoc/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SuperClone/Example1/list-of-projects.properties
+++ b/SuperClone/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SuperClone/Example1/list-of-projects.yml
+++ b/SuperClone/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SuperClone/all-examples-in-one/list-of-projects.properties
+++ b/SuperClone/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SuperClone/all-examples-in-one/list-of-projects.yml
+++ b/SuperClone/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SuperFinalize/Example1/list-of-projects.properties
+++ b/SuperFinalize/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SuperFinalize/Example1/list-of-projects.yml
+++ b/SuperFinalize/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SuperFinalize/all-examples-in-one/list-of-projects.properties
+++ b/SuperFinalize/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SuperFinalize/all-examples-in-one/list-of-projects.yml
+++ b/SuperFinalize/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SuppressWarnings/Example1/list-of-projects.properties
+++ b/SuppressWarnings/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SuppressWarnings/Example1/list-of-projects.yml
+++ b/SuppressWarnings/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SuppressWarnings/Example2/list-of-projects.properties
+++ b/SuppressWarnings/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SuppressWarnings/Example2/list-of-projects.yml
+++ b/SuppressWarnings/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/SuppressWarnings/all-examples-in-one/list-of-projects.properties
+++ b/SuppressWarnings/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/SuppressWarnings/all-examples-in-one/list-of-projects.yml
+++ b/SuppressWarnings/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TextBlockGoogleStyleFormatting/Example1/list-of-projects.properties
+++ b/TextBlockGoogleStyleFormatting/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TextBlockGoogleStyleFormatting/Example1/list-of-projects.yml
+++ b/TextBlockGoogleStyleFormatting/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TextBlockGoogleStyleFormatting/Example2/list-of-projects.properties
+++ b/TextBlockGoogleStyleFormatting/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TextBlockGoogleStyleFormatting/Example2/list-of-projects.yml
+++ b/TextBlockGoogleStyleFormatting/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TextBlockGoogleStyleFormatting/Example3/list-of-projects.properties
+++ b/TextBlockGoogleStyleFormatting/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TextBlockGoogleStyleFormatting/Example3/list-of-projects.yml
+++ b/TextBlockGoogleStyleFormatting/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TextBlockGoogleStyleFormatting/Example4/list-of-projects.properties
+++ b/TextBlockGoogleStyleFormatting/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TextBlockGoogleStyleFormatting/Example4/list-of-projects.yml
+++ b/TextBlockGoogleStyleFormatting/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TextBlockGoogleStyleFormatting/Example5/list-of-projects.properties
+++ b/TextBlockGoogleStyleFormatting/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TextBlockGoogleStyleFormatting/Example5/list-of-projects.yml
+++ b/TextBlockGoogleStyleFormatting/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TextBlockGoogleStyleFormatting/all-examples-in-one/list-of-projects.properties
+++ b/TextBlockGoogleStyleFormatting/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TextBlockGoogleStyleFormatting/all-examples-in-one/list-of-projects.yml
+++ b/TextBlockGoogleStyleFormatting/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ThrowsCount/Example1/list-of-projects.properties
+++ b/ThrowsCount/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ThrowsCount/Example1/list-of-projects.yml
+++ b/ThrowsCount/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ThrowsCount/Example2/list-of-projects.properties
+++ b/ThrowsCount/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ThrowsCount/Example2/list-of-projects.yml
+++ b/ThrowsCount/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ThrowsCount/Example3/list-of-projects.properties
+++ b/ThrowsCount/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ThrowsCount/Example3/list-of-projects.yml
+++ b/ThrowsCount/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/ThrowsCount/all-examples-in-one/list-of-projects.properties
+++ b/ThrowsCount/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/ThrowsCount/all-examples-in-one/list-of-projects.yml
+++ b/ThrowsCount/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TodoComment/Example1/list-of-projects.properties
+++ b/TodoComment/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TodoComment/Example1/list-of-projects.yml
+++ b/TodoComment/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TodoComment/Example2/list-of-projects.properties
+++ b/TodoComment/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TodoComment/Example2/list-of-projects.yml
+++ b/TodoComment/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TodoComment/Example3/list-of-projects.properties
+++ b/TodoComment/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TodoComment/Example3/list-of-projects.yml
+++ b/TodoComment/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TodoComment/all-examples-in-one/list-of-projects.properties
+++ b/TodoComment/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TodoComment/all-examples-in-one/list-of-projects.yml
+++ b/TodoComment/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TrailingComment/Example1/list-of-projects.properties
+++ b/TrailingComment/Example1/list-of-projects.properties
@@ -25,4 +25,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TrailingComment/Example1/list-of-projects.yml
+++ b/TrailingComment/Example1/list-of-projects.yml
@@ -126,4 +126,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TrailingComment/Example2/list-of-projects.properties
+++ b/TrailingComment/Example2/list-of-projects.properties
@@ -25,4 +25,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TrailingComment/Example2/list-of-projects.yml
+++ b/TrailingComment/Example2/list-of-projects.yml
@@ -126,4 +126,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TrailingComment/Example3/list-of-projects.properties
+++ b/TrailingComment/Example3/list-of-projects.properties
@@ -25,4 +25,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TrailingComment/Example3/list-of-projects.yml
+++ b/TrailingComment/Example3/list-of-projects.yml
@@ -126,4 +126,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TrailingComment/Example4/list-of-projects.properties
+++ b/TrailingComment/Example4/list-of-projects.properties
@@ -25,4 +25,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TrailingComment/Example4/list-of-projects.yml
+++ b/TrailingComment/Example4/list-of-projects.yml
@@ -126,4 +126,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TrailingComment/Example5/list-of-projects.properties
+++ b/TrailingComment/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TrailingComment/Example5/list-of-projects.yml
+++ b/TrailingComment/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TrailingComment/Example6/list-of-projects.properties
+++ b/TrailingComment/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TrailingComment/Example6/list-of-projects.yml
+++ b/TrailingComment/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TrailingComment/all-examples-in-one/list-of-projects.properties
+++ b/TrailingComment/all-examples-in-one/list-of-projects.properties
@@ -25,4 +25,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TrailingComment/all-examples-in-one/list-of-projects.yml
+++ b/TrailingComment/all-examples-in-one/list-of-projects.yml
@@ -126,4 +126,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Translation/Example1/list-of-projects.properties
+++ b/Translation/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Translation/Example1/list-of-projects.yml
+++ b/Translation/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Translation/Example2/list-of-projects.properties
+++ b/Translation/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Translation/Example2/list-of-projects.yml
+++ b/Translation/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Translation/Example3/list-of-projects.properties
+++ b/Translation/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Translation/Example3/list-of-projects.yml
+++ b/Translation/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/Translation/all-examples-in-one/list-of-projects.properties
+++ b/Translation/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/Translation/all-examples-in-one/list-of-projects.yml
+++ b/Translation/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypeName/Example1/list-of-projects.properties
+++ b/TypeName/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypeName/Example1/list-of-projects.yml
+++ b/TypeName/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypeName/Example2/list-of-projects.properties
+++ b/TypeName/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypeName/Example2/list-of-projects.yml
+++ b/TypeName/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypeName/Example3/list-of-projects.properties
+++ b/TypeName/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypeName/Example3/list-of-projects.yml
+++ b/TypeName/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypeName/Example4/list-of-projects.properties
+++ b/TypeName/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypeName/Example4/list-of-projects.yml
+++ b/TypeName/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypeName/all-examples-in-one/list-of-projects.properties
+++ b/TypeName/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypeName/all-examples-in-one/list-of-projects.yml
+++ b/TypeName/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypecastParenPad/Example1/list-of-projects.properties
+++ b/TypecastParenPad/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypecastParenPad/Example1/list-of-projects.yml
+++ b/TypecastParenPad/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypecastParenPad/Example2/list-of-projects.properties
+++ b/TypecastParenPad/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypecastParenPad/Example2/list-of-projects.yml
+++ b/TypecastParenPad/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/TypecastParenPad/all-examples-in-one/list-of-projects.properties
+++ b/TypecastParenPad/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/TypecastParenPad/all-examples-in-one/list-of-projects.yml
+++ b/TypecastParenPad/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UncommentedMain/Example1/list-of-projects.properties
+++ b/UncommentedMain/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UncommentedMain/Example1/list-of-projects.yml
+++ b/UncommentedMain/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UncommentedMain/Example2/list-of-projects.properties
+++ b/UncommentedMain/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UncommentedMain/Example2/list-of-projects.yml
+++ b/UncommentedMain/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UncommentedMain/all-examples-in-one/list-of-projects.properties
+++ b/UncommentedMain/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UncommentedMain/all-examples-in-one/list-of-projects.yml
+++ b/UncommentedMain/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UniqueProperties/Example1/list-of-projects.properties
+++ b/UniqueProperties/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UniqueProperties/Example1/list-of-projects.yml
+++ b/UniqueProperties/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UniqueProperties/Example2/list-of-projects.properties
+++ b/UniqueProperties/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UniqueProperties/Example2/list-of-projects.yml
+++ b/UniqueProperties/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UniqueProperties/all-examples-in-one/list-of-projects.properties
+++ b/UniqueProperties/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UniqueProperties/all-examples-in-one/list-of-projects.yml
+++ b/UniqueProperties/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessaryNullCheckWithInstanceOf/Example1/list-of-projects.properties
+++ b/UnnecessaryNullCheckWithInstanceOf/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessaryNullCheckWithInstanceOf/Example1/list-of-projects.yml
+++ b/UnnecessaryNullCheckWithInstanceOf/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessaryNullCheckWithInstanceOf/all-examples-in-one/list-of-projects.properties
+++ b/UnnecessaryNullCheckWithInstanceOf/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessaryNullCheckWithInstanceOf/all-examples-in-one/list-of-projects.yml
+++ b/UnnecessaryNullCheckWithInstanceOf/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessaryParentheses/Example1/list-of-projects.properties
+++ b/UnnecessaryParentheses/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessaryParentheses/Example1/list-of-projects.yml
+++ b/UnnecessaryParentheses/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessaryParentheses/Example2/list-of-projects.properties
+++ b/UnnecessaryParentheses/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessaryParentheses/Example2/list-of-projects.yml
+++ b/UnnecessaryParentheses/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessaryParentheses/Example3/list-of-projects.properties
+++ b/UnnecessaryParentheses/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessaryParentheses/Example3/list-of-projects.yml
+++ b/UnnecessaryParentheses/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessaryParentheses/all-examples-in-one/list-of-projects.properties
+++ b/UnnecessaryParentheses/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessaryParentheses/all-examples-in-one/list-of-projects.yml
+++ b/UnnecessaryParentheses/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/Example1/list-of-projects.properties
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/Example1/list-of-projects.yml
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/Example2/list-of-projects.properties
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/Example2/list-of-projects.yml
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/all-examples-in-one/list-of-projects.properties
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonAfterOuterTypeDeclaration/all-examples-in-one/list-of-projects.yml
+++ b/UnnecessarySemicolonAfterOuterTypeDeclaration/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonAfterTypeMemberDeclaration/Example1/list-of-projects.properties
+++ b/UnnecessarySemicolonAfterTypeMemberDeclaration/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonAfterTypeMemberDeclaration/Example1/list-of-projects.yml
+++ b/UnnecessarySemicolonAfterTypeMemberDeclaration/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonAfterTypeMemberDeclaration/all-examples-in-one/list-of-projects.properties
+++ b/UnnecessarySemicolonAfterTypeMemberDeclaration/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonAfterTypeMemberDeclaration/all-examples-in-one/list-of-projects.yml
+++ b/UnnecessarySemicolonAfterTypeMemberDeclaration/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonInEnumeration/Example1/list-of-projects.properties
+++ b/UnnecessarySemicolonInEnumeration/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonInEnumeration/Example1/list-of-projects.yml
+++ b/UnnecessarySemicolonInEnumeration/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonInEnumeration/Example2/list-of-projects.properties
+++ b/UnnecessarySemicolonInEnumeration/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonInEnumeration/Example2/list-of-projects.yml
+++ b/UnnecessarySemicolonInEnumeration/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonInEnumeration/all-examples-in-one/list-of-projects.properties
+++ b/UnnecessarySemicolonInEnumeration/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonInEnumeration/all-examples-in-one/list-of-projects.yml
+++ b/UnnecessarySemicolonInEnumeration/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonInTryWithResources/Example1/list-of-projects.properties
+++ b/UnnecessarySemicolonInTryWithResources/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonInTryWithResources/Example1/list-of-projects.yml
+++ b/UnnecessarySemicolonInTryWithResources/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonInTryWithResources/Example2/list-of-projects.properties
+++ b/UnnecessarySemicolonInTryWithResources/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonInTryWithResources/Example2/list-of-projects.yml
+++ b/UnnecessarySemicolonInTryWithResources/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnnecessarySemicolonInTryWithResources/all-examples-in-one/list-of-projects.properties
+++ b/UnnecessarySemicolonInTryWithResources/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnnecessarySemicolonInTryWithResources/all-examples-in-one/list-of-projects.yml
+++ b/UnnecessarySemicolonInTryWithResources/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedCatchParameterShouldBeUnnamed/Example1/list-of-projects.properties
+++ b/UnusedCatchParameterShouldBeUnnamed/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedCatchParameterShouldBeUnnamed/Example1/list-of-projects.yml
+++ b/UnusedCatchParameterShouldBeUnnamed/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedCatchParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.properties
+++ b/UnusedCatchParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedCatchParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.yml
+++ b/UnusedCatchParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedImports/Example1/list-of-projects.properties
+++ b/UnusedImports/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedImports/Example1/list-of-projects.yml
+++ b/UnusedImports/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedImports/Example2/list-of-projects.properties
+++ b/UnusedImports/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedImports/Example2/list-of-projects.yml
+++ b/UnusedImports/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedImports/all-examples-in-one/list-of-projects.properties
+++ b/UnusedImports/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedImports/all-examples-in-one/list-of-projects.yml
+++ b/UnusedImports/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedLambdaParameterShouldBeUnnamed/Example1/list-of-projects.properties
+++ b/UnusedLambdaParameterShouldBeUnnamed/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedLambdaParameterShouldBeUnnamed/Example1/list-of-projects.yml
+++ b/UnusedLambdaParameterShouldBeUnnamed/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedLambdaParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.properties
+++ b/UnusedLambdaParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedLambdaParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.yml
+++ b/UnusedLambdaParameterShouldBeUnnamed/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedLocalVariable/Example1/list-of-projects.properties
+++ b/UnusedLocalVariable/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedLocalVariable/Example1/list-of-projects.yml
+++ b/UnusedLocalVariable/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedLocalVariable/Example2/list-of-projects.properties
+++ b/UnusedLocalVariable/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedLocalVariable/Example2/list-of-projects.yml
+++ b/UnusedLocalVariable/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedLocalVariable/Example3/list-of-projects.properties
+++ b/UnusedLocalVariable/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedLocalVariable/Example3/list-of-projects.yml
+++ b/UnusedLocalVariable/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedLocalVariable/Example4/list-of-projects.properties
+++ b/UnusedLocalVariable/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedLocalVariable/Example4/list-of-projects.yml
+++ b/UnusedLocalVariable/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedLocalVariable/all-examples-in-one/list-of-projects.properties
+++ b/UnusedLocalVariable/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedLocalVariable/all-examples-in-one/list-of-projects.yml
+++ b/UnusedLocalVariable/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedTryResourceShouldBeUnnamed/Example1/list-of-projects.properties
+++ b/UnusedTryResourceShouldBeUnnamed/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedTryResourceShouldBeUnnamed/Example1/list-of-projects.yml
+++ b/UnusedTryResourceShouldBeUnnamed/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UnusedTryResourceShouldBeUnnamed/all-examples-in-one/list-of-projects.properties
+++ b/UnusedTryResourceShouldBeUnnamed/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UnusedTryResourceShouldBeUnnamed/all-examples-in-one/list-of-projects.yml
+++ b/UnusedTryResourceShouldBeUnnamed/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UpperEll/Example1/list-of-projects.properties
+++ b/UpperEll/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UpperEll/Example1/list-of-projects.yml
+++ b/UpperEll/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UpperEll/all-examples-in-one/list-of-projects.properties
+++ b/UpperEll/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UpperEll/all-examples-in-one/list-of-projects.yml
+++ b/UpperEll/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UseEnhancedSwitch/Example1/list-of-projects.properties
+++ b/UseEnhancedSwitch/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UseEnhancedSwitch/Example1/list-of-projects.yml
+++ b/UseEnhancedSwitch/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UseEnhancedSwitch/Example2/list-of-projects.properties
+++ b/UseEnhancedSwitch/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UseEnhancedSwitch/Example2/list-of-projects.yml
+++ b/UseEnhancedSwitch/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/UseEnhancedSwitch/all-examples-in-one/list-of-projects.properties
+++ b/UseEnhancedSwitch/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/UseEnhancedSwitch/all-examples-in-one/list-of-projects.yml
+++ b/UseEnhancedSwitch/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VariableDeclarationUsageDistance/Example1/list-of-projects.properties
+++ b/VariableDeclarationUsageDistance/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VariableDeclarationUsageDistance/Example1/list-of-projects.yml
+++ b/VariableDeclarationUsageDistance/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VariableDeclarationUsageDistance/Example2/list-of-projects.properties
+++ b/VariableDeclarationUsageDistance/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VariableDeclarationUsageDistance/Example2/list-of-projects.yml
+++ b/VariableDeclarationUsageDistance/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VariableDeclarationUsageDistance/Example3/list-of-projects.properties
+++ b/VariableDeclarationUsageDistance/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VariableDeclarationUsageDistance/Example3/list-of-projects.yml
+++ b/VariableDeclarationUsageDistance/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VariableDeclarationUsageDistance/Example4/list-of-projects.properties
+++ b/VariableDeclarationUsageDistance/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VariableDeclarationUsageDistance/Example4/list-of-projects.yml
+++ b/VariableDeclarationUsageDistance/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VariableDeclarationUsageDistance/Example5/list-of-projects.properties
+++ b/VariableDeclarationUsageDistance/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VariableDeclarationUsageDistance/Example5/list-of-projects.yml
+++ b/VariableDeclarationUsageDistance/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VariableDeclarationUsageDistance/Example6/list-of-projects.properties
+++ b/VariableDeclarationUsageDistance/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VariableDeclarationUsageDistance/Example6/list-of-projects.yml
+++ b/VariableDeclarationUsageDistance/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VariableDeclarationUsageDistance/all-examples-in-one/list-of-projects.properties
+++ b/VariableDeclarationUsageDistance/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VariableDeclarationUsageDistance/all-examples-in-one/list-of-projects.yml
+++ b/VariableDeclarationUsageDistance/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example1/list-of-projects.properties
+++ b/VisibilityModifier/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example1/list-of-projects.yml
+++ b/VisibilityModifier/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example10/list-of-projects.properties
+++ b/VisibilityModifier/Example10/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example10/list-of-projects.yml
+++ b/VisibilityModifier/Example10/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example11/list-of-projects.properties
+++ b/VisibilityModifier/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example11/list-of-projects.yml
+++ b/VisibilityModifier/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example12/list-of-projects.properties
+++ b/VisibilityModifier/Example12/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example12/list-of-projects.yml
+++ b/VisibilityModifier/Example12/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example2/list-of-projects.properties
+++ b/VisibilityModifier/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example2/list-of-projects.yml
+++ b/VisibilityModifier/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example3/list-of-projects.properties
+++ b/VisibilityModifier/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example3/list-of-projects.yml
+++ b/VisibilityModifier/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example4/list-of-projects.properties
+++ b/VisibilityModifier/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example4/list-of-projects.yml
+++ b/VisibilityModifier/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example5/list-of-projects.properties
+++ b/VisibilityModifier/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example5/list-of-projects.yml
+++ b/VisibilityModifier/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example6/list-of-projects.properties
+++ b/VisibilityModifier/Example6/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example6/list-of-projects.yml
+++ b/VisibilityModifier/Example6/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example7/list-of-projects.properties
+++ b/VisibilityModifier/Example7/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example7/list-of-projects.yml
+++ b/VisibilityModifier/Example7/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example8/list-of-projects.properties
+++ b/VisibilityModifier/Example8/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example8/list-of-projects.yml
+++ b/VisibilityModifier/Example8/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/Example9/list-of-projects.properties
+++ b/VisibilityModifier/Example9/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/Example9/list-of-projects.yml
+++ b/VisibilityModifier/Example9/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/VisibilityModifier/all-examples-in-one/list-of-projects.properties
+++ b/VisibilityModifier/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/VisibilityModifier/all-examples-in-one/list-of-projects.yml
+++ b/VisibilityModifier/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhenShouldBeUsed/Example1/list-of-projects.properties
+++ b/WhenShouldBeUsed/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhenShouldBeUsed/Example1/list-of-projects.yml
+++ b/WhenShouldBeUsed/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhenShouldBeUsed/all-examples-in-one/list-of-projects.properties
+++ b/WhenShouldBeUsed/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhenShouldBeUsed/all-examples-in-one/list-of-projects.yml
+++ b/WhenShouldBeUsed/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAfter/Example1/list-of-projects.properties
+++ b/WhitespaceAfter/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAfter/Example1/list-of-projects.yml
+++ b/WhitespaceAfter/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAfter/Example2/list-of-projects.properties
+++ b/WhitespaceAfter/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAfter/Example2/list-of-projects.yml
+++ b/WhitespaceAfter/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAfter/all-examples-in-one/list-of-projects.properties
+++ b/WhitespaceAfter/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAfter/all-examples-in-one/list-of-projects.yml
+++ b/WhitespaceAfter/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example1/list-of-projects.properties
+++ b/WhitespaceAround/Example1/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example1/list-of-projects.yml
+++ b/WhitespaceAround/Example1/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example10/list-of-projects.properties
+++ b/WhitespaceAround/Example10/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example10/list-of-projects.yml
+++ b/WhitespaceAround/Example10/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example11/list-of-projects.properties
+++ b/WhitespaceAround/Example11/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example11/list-of-projects.yml
+++ b/WhitespaceAround/Example11/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example2/list-of-projects.properties
+++ b/WhitespaceAround/Example2/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example2/list-of-projects.yml
+++ b/WhitespaceAround/Example2/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example3/list-of-projects.properties
+++ b/WhitespaceAround/Example3/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example3/list-of-projects.yml
+++ b/WhitespaceAround/Example3/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example4/list-of-projects.properties
+++ b/WhitespaceAround/Example4/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example4/list-of-projects.yml
+++ b/WhitespaceAround/Example4/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example5/list-of-projects.properties
+++ b/WhitespaceAround/Example5/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example5/list-of-projects.yml
+++ b/WhitespaceAround/Example5/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example6/list-of-projects.properties
+++ b/WhitespaceAround/Example6/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example6/list-of-projects.yml
+++ b/WhitespaceAround/Example6/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example7/list-of-projects.properties
+++ b/WhitespaceAround/Example7/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example7/list-of-projects.yml
+++ b/WhitespaceAround/Example7/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example8/list-of-projects.properties
+++ b/WhitespaceAround/Example8/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example8/list-of-projects.yml
+++ b/WhitespaceAround/Example8/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/Example9/list-of-projects.properties
+++ b/WhitespaceAround/Example9/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/Example9/list-of-projects.yml
+++ b/WhitespaceAround/Example9/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WhitespaceAround/all-examples-in-one/list-of-projects.properties
+++ b/WhitespaceAround/all-examples-in-one/list-of-projects.properties
@@ -29,4 +29,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WhitespaceAround/all-examples-in-one/list-of-projects.yml
+++ b/WhitespaceAround/all-examples-in-one/list-of-projects.yml
@@ -425,4 +425,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WriteTag/Example1/list-of-projects.properties
+++ b/WriteTag/Example1/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WriteTag/Example1/list-of-projects.yml
+++ b/WriteTag/Example1/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WriteTag/Example2/list-of-projects.properties
+++ b/WriteTag/Example2/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WriteTag/Example2/list-of-projects.yml
+++ b/WriteTag/Example2/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WriteTag/Example3/list-of-projects.properties
+++ b/WriteTag/Example3/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WriteTag/Example3/list-of-projects.yml
+++ b/WriteTag/Example3/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WriteTag/Example4/list-of-projects.properties
+++ b/WriteTag/Example4/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WriteTag/Example4/list-of-projects.yml
+++ b/WriteTag/Example4/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WriteTag/Example5/list-of-projects.properties
+++ b/WriteTag/Example5/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WriteTag/Example5/list-of-projects.yml
+++ b/WriteTag/Example5/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/WriteTag/all-examples-in-one/list-of-projects.properties
+++ b/WriteTag/all-examples-in-one/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/WriteTag/all-examples-in-one/list-of-projects.yml
+++ b/WriteTag/all-examples-in-one/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112

--- a/extractor/src/main/resources/all-projects.properties
+++ b/extractor/src/main/resources/all-projects.properties
@@ -40,7 +40,7 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||
 
 # japan language
 WxJava|git|https://github.com/Wechat-Group/WxJava.git|develop|

--- a/extractor/src/main/resources/all-projects.yml
+++ b/extractor/src/main/resources/all-projects.yml
@@ -430,7 +430,7 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112
 
   # Japan Language
   - name: WxJava

--- a/extractor/src/main/resources/list-of-projects.properties
+++ b/extractor/src/main/resources/list-of-projects.properties
@@ -40,4 +40,4 @@ infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
 protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
 jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
 RxJava|git|https://github.com/ReactiveX/RxJava|v1.0.9||
-Vavr|git|https://github.com/vavr-io/vavr|6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0||
+Vavr|git|https://github.com/vavr-io/vavr|519061238d7df5d5b16e9b187e4b971562ddb112||

--- a/extractor/src/main/resources/list-of-projects.yml
+++ b/extractor/src/main/resources/list-of-projects.yml
@@ -440,4 +440,4 @@ projects:
   - name: Vavr
     scm: git
     url: https://github.com/vavr-io/vavr
-    reference: 6f908f7dcf13567ae2fbeb4dcf9db45f8cf951a0
+    reference: 519061238d7df5d5b16e9b187e4b971562ddb112


### PR DESCRIPTION
closes #240

The previous Vavr reference pointed to the PR/fork head SHA, which is not reachable from the upstream clone after squash merge; this updates it to the commit that actually exists in vavr-io/vavr.