### PR TITLE
fix OutOfMemoryError in postProcessCheckstyleReport for large …

### DIFF
--- a/diff-java-tool/src/main/java/com/github/checkstyle/difftool/DiffTool.java
+++ b/diff-java-tool/src/main/java/com/github/checkstyle/difftool/DiffTool.java
@@ -1797,11 +1797,22 @@ public final class DiffTool {
     private static void postProcessCheckstyleReport(final String targetDir,
                     final String repoName, final String repoPath) throws IOException {
         final Path reportPath = Paths.get(targetDir, "checkstyle-result.xml");
-        String content = new String(Files.readAllBytes(reportPath), StandardCharsets.UTF_8);
-        content = content
-                .replace(new File(getOsSpecificPath("src", "main", "java", repoName))
-                .getAbsolutePath(), getOsSpecificPath(repoPath));
-        Files.write(reportPath, content.getBytes(StandardCharsets.UTF_8));
+        final String absolutePath = new File(getOsSpecificPath("src", "main", "java", repoName))
+                .getAbsolutePath();
+        final String relativePath = getOsSpecificPath(repoPath);
+
+        final Path tempPath = Files.createTempFile("temp", ".xml");
+        try (BufferedReader reader = Files.newBufferedReader(reportPath, StandardCharsets.UTF_8);
+             BufferedWriter writer = Files.newBufferedWriter(tempPath, StandardCharsets.UTF_8)) {
+            String line = reader.readLine();
+            while (line != null) {
+                writer.write(line.replace(absolutePath, relativePath));
+                writer.newLine();
+                line = reader.readLine();
+            }
+        }
+        Files.copy(tempPath, reportPath, StandardCopyOption.REPLACE_EXISTING);
+        Files.delete(tempPath);
     }
 
     /**

--- a/diff-java-tool/src/test/java/com/github/checkstyle/difftool/DiffToolTest.java
+++ b/diff-java-tool/src/test/java/com/github/checkstyle/difftool/DiffToolTest.java
@@ -26,10 +26,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.cli.CommandLine;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test class for DiffTool.
@@ -320,6 +325,48 @@ class DiffToolTest {
         final Method getModeMethod = configClass.getMethod("getMode");
         final String mode = (String) getModeMethod.invoke(configInstance);
         assertEquals("diff", mode, "Mode should be 'diff'");
+    }
+
+    /**
+     * Tests that postProcessCheckstyleReport rewrites the local absolute source path
+     * prefix to the repository path while streaming the report line by line, leaving
+     * unrelated lines untouched.
+     *
+     * @param tempDir a temporary directory for the report, provided by JUnit
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    void testPostProcessCheckstyleReportRewritesPaths(@TempDir final Path tempDir)
+            throws Exception {
+        final String repoName = "mockRepo";
+        final String repoPath = "/repos/mockRepo";
+        final String localPathPrefix = new File(
+                "src" + File.separator + "main" + File.separator + "java"
+                        + File.separator + repoName).getAbsolutePath();
+
+        final Path reportPath = tempDir.resolve("checkstyle-result.xml");
+        final List<String> originalLines = List.of(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<checkstyle version=\"10.17.0\">",
+                "<file name=\"" + localPathPrefix + File.separator + "Foo.java\">",
+                "<error line=\"1\" message=\"unrelated\"/>",
+                "</file>",
+                "<file name=\"" + localPathPrefix + File.separator + "Bar.java\">",
+                "</file>",
+                "</checkstyle>");
+        Files.write(reportPath, originalLines, StandardCharsets.UTF_8);
+
+        final Method method = getDeclaredMethod("postProcessCheckstyleReport",
+                String.class, String.class, String.class);
+        method.invoke(null, tempDir.toString(), repoName, repoPath);
+
+        final String result = Files.readString(reportPath, StandardCharsets.UTF_8);
+        assertFalse(result.contains(localPathPrefix),
+                "Local absolute path prefix should have been replaced");
+        assertTrue(result.contains(repoPath + File.separator + "Foo.java"),
+                "Path should have been rewritten to the repository path");
+        assertTrue(result.contains("message=\"unrelated\""),
+                "Unrelated content should be preserved");
     }
 
     private Method getDeclaredMethod(final String methodName,


### PR DESCRIPTION
postProcessCheckstyleReport rewrites the local source-path prefix inside checkstyle-result.xml by reading the whole file into a single String. When a noisy check (e.g. Indentation) runs over a large project like openjdk or spring-framework, the report can exceed 1 GB and blow past the JVM's ~1.07 billion character String limit, crashing the run with OutOfMemoryError: UTF16 String size ..., should be less than 1073741823.

This ports the fix already merged in the Groovy version (diff.groovy, [checkstyle/contribution Issue #1039](https://github.com/checkstyle/contribution/issues/1039)): read the report line by line, apply the path replacement per line, write through a temp file, then copy back. Memory is now constant regardless of report size, and output is identical to before.

issue encountered at https://github.com/checkstyle/checkstyle/actions/runs/29201471256/job/86676313441

```
[INFO] Generating "Checkstyle" report           --- maven-checkstyle-plugin:3.1.1:checkstyle
line 27:12 token recognition error at: '\'
line 66:38 token recognition error at: '\'
line 27:22 token recognition error at: '\'
Warning:  Unable to locate Source XRef to link to - DISABLED
Warning:  An issue has occurred with maven-checkstyle-plugin:3.1.1:checkstyle report, skipping LinkageError org/apache/maven/doxia/sink/SinkEventAttributeSet, please report an issue to Maven dev team.
java.lang.NoClassDefFoundError: org/apache/maven/doxia/sink/SinkEventAttributeSet
    at org.apache.maven.plugins.checkstyle.CheckstyleReportGenerator.doDetails (CheckstyleReportGenerator.java:602)
    at org.apache.maven.plugins.checkstyle.CheckstyleReportGenerator.generateReport (CheckstyleReportGenerator.java:152)
    at org.apache.maven.plugins.checkstyle.AbstractCheckstyleReport.generateMainReport (AbstractCheckstyleReport.java:780)
    at org.apache.maven.plugins.checkstyle.AbstractCheckstyleReport.executeReport (AbstractCheckstyleReport.java:537)
    at org.apache.maven.plugins.checkstyle.CheckstyleReport.executeReport (CheckstyleReport.java:57)
    at org.apache.maven.reporting.AbstractMavenReport.generate (AbstractMavenReport.java:255)
    at org.apache.maven.plugins.site.render.ReportDocumentRenderer.renderDocument (ReportDocumentRenderer.java:226)
    at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render (DefaultSiteRenderer.java:348)
    at org.apache.maven.plugins.site.render.SiteMojo.renderLocale (SiteMojo.java:194)
    at org.apache.maven.plugins.site.render.SiteMojo.execute (SiteMojo.java:143)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:919)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:285)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:207)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:362)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
Caused by: java.lang.ClassNotFoundException: org.apache.maven.doxia.sink.SinkEventAttributeSet
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass (SelfFirstStrategy.java:42)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass (ClassRealm.java:211)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:202)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:198)
    at org.apache.maven.plugins.checkstyle.CheckstyleReportGenerator.doDetails (CheckstyleReportGenerator.java:602)
    at org.apache.maven.plugins.checkstyle.CheckstyleReportGenerator.generateReport (CheckstyleReportGenerator.java:152)
    at org.apache.maven.plugins.checkstyle.AbstractCheckstyleReport.generateMainReport (AbstractCheckstyleReport.java:780)
    at org.apache.maven.plugins.checkstyle.AbstractCheckstyleReport.executeReport (AbstractCheckstyleReport.java:537)
    at org.apache.maven.plugins.checkstyle.CheckstyleReport.executeReport (CheckstyleReport.java:57)
    at org.apache.maven.reporting.AbstractMavenReport.generate (AbstractMavenReport.java:255)
    at org.apache.maven.plugins.site.render.ReportDocumentRenderer.renderDocument (ReportDocumentRenderer.java:226)
    at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render (DefaultSiteRenderer.java:348)
    at org.apache.maven.plugins.site.render.SiteMojo.renderLocale (SiteMojo.java:194)
    at org.apache.maven.plugins.site.render.SiteMojo.execute (SiteMojo.java:143)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:919)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:285)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:207)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:362)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15:36 min
[INFO] Finished at: 2026-07-12T18:57:29Z
[INFO] ------------------------------------------------------------------------
[main] INFO com.github.checkstyle.difftool.DiffTool - Running Checkstyle on src/main/java - finished
Error: Exception in thread "main" java.lang.OutOfMemoryError: UTF16 String size is 1898496287, should be less than 1073741823
	at java.base/java.lang.StringUTF16.newBytesLength(StringUTF16.java:57)
	at java.base/java.lang.StringUTF16.newBytesFor(StringUTF16.java:47)
	at java.base/java.lang.String.<init>(String.java:572)
	at java.base/java.lang.String.<init>(String.java:1414)
	at com.github.checkstyle.difftool.DiffTool.postProcessCheckstyleReport(DiffTool.java:1795)
	at com.github.checkstyle.difftool.DiffTool.generateCheckstyleReport(DiffTool.java:757)
	at com.github.checkstyle.difftool.DiffTool.launchCheckstyleReport(DiffTool.java:683)
	at com.github.checkstyle.difftool.DiffTool.main(DiffTool.java:177)

```